### PR TITLE
[refactor]: craco alias를 사용한 절대 경로 변경,  TanStack Query 적용/ [feat]: 리뷰 목록 및 리뷰 등록 기능(msw를 사용한 api 모킹)  

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -1,0 +1,15 @@
+const { CracoAliasPlugin } = require("react-app-alias");
+
+module.exports = {
+  plugins: [
+    {
+      plugin: CracoAliasPlugin,
+      options: {
+        source: "tsconfig",
+        baseUrl: ".",
+        tsConfigPath: "tsconfig.paths.json",
+        debug: false,
+      },
+    },
+  ],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,8 @@
       },
       "devDependencies": {
         "@craco/craco": "^7.1.0",
+        "@faker-js/faker": "^8.4.1",
+        "msw": "^2.2.3",
         "react-app-alias": "^2.2.2"
       }
     },
@@ -2034,6 +2036,24 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
+    "node_modules/@bundled-es-modules/cookie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.0.tgz",
+      "integrity": "sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==",
+      "dev": true,
+      "dependencies": {
+        "cookie": "^0.5.0"
+      }
+    },
+    "node_modules/@bundled-es-modules/statuses": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+      "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+      "dev": true,
+      "dependencies": {
+        "statuses": "^2.0.1"
+      }
+    },
     "node_modules/@craco/craco": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@craco/craco/-/craco-7.1.0.tgz",
@@ -2461,6 +2481,22 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@faker-js/faker": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.1.tgz",
+      "integrity": "sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=6.14.13"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -2490,6 +2526,158 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
       "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw=="
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.0.2.tgz",
+      "integrity": "sha512-eEhoJXten380e2t2yahRRMz1LqB4gKknl5//38k1KvKXhBcV+lFfkIPmr6nFivpIwtOwkaRjGcHz67wBmi3h6Q==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/core": "^7.0.2",
+        "@inquirer/type": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-7.0.2.tgz",
+      "integrity": "sha512-yya2GLO8lIi+yGytrOQ6unbrRGi8JiC+lWtlIsCUsDgMcCdO75vOuqGIUKXvfBkeZLOzs4WcSioXvpBzo0B0+Q==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/type": "^1.2.0",
+        "@types/mute-stream": "^0.0.4",
+        "@types/node": "^20.11.25",
+        "@types/wrap-ansi": "^3.0.0",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "cli-spinners": "^2.9.2",
+        "cli-width": "^4.1.0",
+        "figures": "^3.2.0",
+        "mute-stream": "^1.0.0",
+        "run-async": "^3.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/@types/node": {
+      "version": "20.11.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.25.tgz",
+      "integrity": "sha512-TBHyJxk2b7HceLVGFcpAUjsa5zIdsPWlR6XHfyGzd0SFu+/NFgQgMAl96MSDZgQDvJAvV6BKsFOrt6zIL09JDw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@inquirer/core/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-/vvkUkYhrjbm+RolU7V1aUFDydZVKNKqKHR5TsE+j5DXgXFwrsOPcoGUJ02K0O7q7O53CU2DOTMYCHeGZ25WHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -3300,6 +3488,32 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
+    "node_modules/@mswjs/cookies": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
+      "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.25.16",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.16.tgz",
+      "integrity": "sha512-8QC8JyKztvoGAdPgyZy49c9vSHHAZjHagwl4RY9E8carULk8ym3iTaiawrT1YoLF/qb449h48f71XDPgkUSOUg==",
+      "dev": true,
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.2.1",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -3359,6 +3573,28 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -4219,6 +4455,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true
+    },
     "node_modules/@types/eslint": {
       "version": "8.56.2",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.2.tgz",
@@ -4348,6 +4590,15 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
+    },
+    "node_modules/@types/mute-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
+      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "16.18.82",
@@ -4492,6 +4743,12 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="
     },
+    "node_modules/@types/statuses": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.5.tgz",
+      "integrity": "sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==",
+      "dev": true
+    },
     "node_modules/@types/styled-components": {
       "version": "5.1.34",
       "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.34.tgz",
@@ -4519,6 +4776,12 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
+    },
+    "node_modules/@types/wrap-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
@@ -6129,6 +6392,27 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/cliui": {
@@ -8410,6 +8694,21 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -9099,6 +9398,15 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
     },
+    "node_modules/graphql": {
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/gzip-size": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
@@ -9204,6 +9512,12 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
+      "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
+      "dev": true
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -9834,6 +10148,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -12797,6 +13117,179 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/msw": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.2.3.tgz",
+      "integrity": "sha512-84CoNCkcJ/EvY8Tv0tD/6HKVd4S5HyGowHjM5W12K8Wgryp4fikqS7IaTOceyQgP5dNedxo2icTLDXo7dkpxCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@bundled-es-modules/cookie": "^2.0.0",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@inquirer/confirm": "^3.0.0",
+        "@mswjs/cookies": "^1.1.0",
+        "@mswjs/interceptors": "^0.25.16",
+        "@open-draft/until": "^2.1.0",
+        "@types/cookie": "^0.6.0",
+        "@types/statuses": "^2.0.4",
+        "chalk": "^4.1.2",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.2",
+        "path-to-regexp": "^6.2.0",
+        "strict-event-emitter": "^0.5.1",
+        "type-fest": "^4.9.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.7.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/msw/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/msw/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/msw/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/msw/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/msw/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/msw/node_modules/path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+      "dev": true
+    },
+    "node_modules/msw/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.12.0.tgz",
+      "integrity": "sha512-5Y2/pp2wtJk8o08G0CMkuFPCO354FGwk/vbidxrdhRGZfd0tFnb4Qb8anp9XxXriwBgVPjdWbKpGl4J9lJY2jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/msw/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/msw/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
@@ -12807,6 +13300,15 @@
       },
       "bin": {
         "multicast-dns": "cli.js"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/mz": {
@@ -13168,6 +13670,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.2.tgz",
+      "integrity": "sha512-Ou3dJ6bA/UJ5GVHxah4LnqDwZRwAmWxrG3wtrHrbGnP4RnLCtA64A4F+ae7Y8ww660JaddSoArUR5HjipWSHAQ==",
+      "dev": true
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -15650,6 +16158,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/run-async": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -16354,6 +16871,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -17406,6 +17929,12 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
       "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@react-icons/all-files": "^4.1.0",
         "@tanstack/react-query": "^5.25.0",
+        "@tanstack/react-query-devtools": "^5.25.0",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -3760,6 +3761,15 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.24.0.tgz",
+      "integrity": "sha512-pThim455t69zrZaQKa7IRkEIK8UBTS+gHVAdNfhO72Xh4rWpMc63ovRje5/n6iw63+d6QiJzVadsJVdPoodSeQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/react-query": {
       "version": "5.25.0",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.25.0.tgz",
@@ -3772,6 +3782,22 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.25.0.tgz",
+      "integrity": "sha512-bqtr1Bwvo/jspJXb2l4R1DSZ848TvIzGBk4V0b6YGS5EQ3015dhm3mPqyTgh0DquK5ZR0h1yP/4DpzhhvTnFHA==",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.24.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.25.0",
         "react": "^18.0.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,10 @@
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4",
         "zustand": "^4.5.1"
+      },
+      "devDependencies": {
+        "@craco/craco": "^7.1.0",
+        "react-app-alias": "^2.2.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2028,6 +2032,52 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
+    "node_modules/@craco/craco": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@craco/craco/-/craco-7.1.0.tgz",
+      "integrity": "sha512-oRAcPIKYrfPXp9rSzlsDNeOaVtDiKhoyqSXUoqiK24jCkHr4T8m/a2f74yXIzCbIheoUWDOIfWZyRgFgT+cpqA==",
+      "dev": true,
+      "dependencies": {
+        "autoprefixer": "^10.4.12",
+        "cosmiconfig": "^7.0.1",
+        "cosmiconfig-typescript-loader": "^1.0.0",
+        "cross-spawn": "^7.0.3",
+        "lodash": "^4.17.21",
+        "semver": "^7.3.7",
+        "webpack-merge": "^5.8.0"
+      },
+      "bin": {
+        "craco": "dist/bin/craco.js"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "react-scripts": "^5.0.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "devOptional": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "devOptional": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@csstools/normalize.css": {
       "version": "12.1.1",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.1.1.tgz",
@@ -4017,6 +4067,30 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "devOptional": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "devOptional": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "devOptional": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "devOptional": true
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
@@ -6016,6 +6090,20 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "dev": true,
+      "dependencies": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6255,6 +6343,31 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/cosmiconfig-typescript-loader": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.9.tgz",
+      "integrity": "sha512-tRuMRhxN4m1Y8hP9SNYfz7jRwt8lZdWxdjg/ohg5esKmsndJIn4yT96oJVcf5x0eA11taXl+sIp+ielu529k6g==",
+      "dev": true,
+      "dependencies": {
+        "cosmiconfig": "^7",
+        "ts-node": "^10.7.0"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "cosmiconfig": ">=7",
+        "typescript": ">=3"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "devOptional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -6922,6 +7035,15 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/diff-sequences": {
       "version": "27.5.1",
@@ -8374,6 +8496,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -9702,6 +9833,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -9866,6 +10009,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -12356,6 +12508,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "devOptional": true
+    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -14744,6 +14902,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-app-alias": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-app-alias/-/react-app-alias-2.2.2.tgz",
+      "integrity": "sha512-mkebUkGLEBA8A8jripu5h1e3cccGl8wWHCUmyJo43/KhaN91DO3qyCLWGWneogqkG4PWhp2JHtlCJ06YSdHVYQ==",
+      "dev": true
+    },
     "node_modules/react-app-polyfill": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-3.0.0.tgz",
@@ -15811,6 +15975,18 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/shallowequal": {
       "version": "1.1.0",
@@ -16919,6 +17095,64 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "devOptional": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "devOptional": true
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -17293,6 +17527,12 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "devOptional": true
+    },
     "node_modules/v8-to-istanbul": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.1.tgz",
@@ -17659,6 +17899,20 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "dev": true,
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/webpack-sources": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
@@ -17835,6 +18089,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/wildcard": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
+      "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
+      "dev": true
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
@@ -18323,6 +18583,15 @@
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@react-icons/all-files": "^4.1.0",
+        "@tanstack/react-query": "^5.25.0",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -3748,6 +3749,30 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.25.0.tgz",
+      "integrity": "sha512-vlobHP64HTuSE68lWF1mEhwSRC5Q7gaT+a/m9S+ItuN+ruSOxe1rFnR9j0ACWQ314BPhBEVKfBQ6mHL0OWfdbQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.25.0.tgz",
+      "integrity": "sha512-u+n5R7mLO7RmeiIonpaCRVXNRWtZEef/aVZ/XGWRPa7trBIvGtzlfo0Ah7ZtnTYfrKEVwnZ/tzRCBcoiqJ/tFw==",
+      "dependencies": {
+        "@tanstack/query-core": "5.25.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "zustand": "^4.5.1"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
+    "start": "craco start",
+    "build": "craco build",
+    "test": "craco test",
     "eject": "react-scripts eject",
     "typecheck": "tsc --noEmit --skipLibCheck"
   },
@@ -50,5 +50,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@craco/craco": "^7.1.0",
+    "react-app-alias": "^2.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,13 @@
   },
   "devDependencies": {
     "@craco/craco": "^7.1.0",
+    "@faker-js/faker": "^8.4.1",
+    "msw": "^2.2.3",
     "react-app-alias": "^2.2.2"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@react-icons/all-files": "^4.1.0",
+    "@tanstack/react-query": "^5.25.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@react-icons/all-files": "^4.1.0",
     "@tanstack/react-query": "^5.25.0",
+    "@tanstack/react-query-devtools": "^5.25.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,287 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker (2.2.3).
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ * - Please do NOT serve this file on production.
+ */
+
+const INTEGRITY_CHECKSUM = '223d191a56023cd36aa88c802961b911'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+self.addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+self.addEventListener('message', async function (event) {
+  const clientId = event.source.id
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: INTEGRITY_CHECKSUM,
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: true,
+      })
+      break
+    }
+
+    case 'MOCK_DEACTIVATE': {
+      activeClientIds.delete(clientId)
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+self.addEventListener('fetch', function (event) {
+  const { request } = event
+
+  // Bypass navigation requests.
+  if (request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  // Generate unique request ID.
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId))
+})
+
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event)
+  const response = await getResponse(event, client, requestId)
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    ;(async function () {
+      const responseClone = response.clone()
+
+      sendToClient(
+        client,
+        {
+          type: 'RESPONSE',
+          payload: {
+            requestId,
+            isMockedResponse: IS_MOCKED_RESPONSE in response,
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            body: responseClone.body,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+          },
+        },
+        [responseClone.body],
+      )
+    })()
+  }
+
+  return response
+}
+
+// Resolve the main client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+async function getResponse(event, client, requestId) {
+  const { request } = event
+
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = request.clone()
+
+  function passthrough() {
+    const headers = Object.fromEntries(requestClone.headers.entries())
+
+    // Remove internal MSW request header so the passthrough request
+    // complies with any potential CORS preflight checks on the server.
+    // Some servers forbid unknown request headers.
+    delete headers['x-msw-intention']
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Bypass requests with the explicit bypass header.
+  // Such requests can be issued by "ctx.fetch()".
+  const mswIntention = request.headers.get('x-msw-intention')
+  if (['bypass', 'passthrough'].includes(mswIntention)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const requestBuffer = await request.arrayBuffer()
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        url: request.url,
+        mode: request.mode,
+        method: request.method,
+        headers: Object.fromEntries(request.headers.entries()),
+        cache: request.cache,
+        credentials: request.credentials,
+        destination: request.destination,
+        integrity: request.integrity,
+        redirect: request.redirect,
+        referrer: request.referrer,
+        referrerPolicy: request.referrerPolicy,
+        body: requestBuffer,
+        keepalive: request.keepalive,
+      },
+    },
+    [requestBuffer],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'MOCK_NOT_FOUND': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(
+      message,
+      [channel.port2].concat(transferrables.filter(Boolean)),
+    )
+  })
+}
+
+async function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,16 @@
 import { BookShopThemeProvider } from "./context/ThemeContext";
 import { RouterProvider } from "react-router-dom";
 import { router } from "./routers/router";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { queryClient } from "./api/queryClient";
 
 function App() {
   return (
-    <BookShopThemeProvider>
-      <RouterProvider router={router} />
-    </BookShopThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <BookShopThemeProvider>
+        <RouterProvider router={router} />
+      </BookShopThemeProvider>
+    </QueryClientProvider>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { RouterProvider } from "react-router-dom";
 import { router } from "./routers/router";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "./api/queryClient";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 function App() {
   return (
@@ -10,6 +11,7 @@ function App() {
       <BookShopThemeProvider>
         <RouterProvider router={router} />
       </BookShopThemeProvider>
+      <ReactQueryDevtools />
     </QueryClientProvider>
   );
 }

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -1,7 +1,7 @@
-import { LoginProps } from "../pages/LoginPage";
-import { ResetProps } from "../pages/ResetPasswordPage";
-import { JoinProps } from "./../pages/JoinPage";
-import { httpClient } from "./http";
+import { LoginProps } from "@/pages/LoginPage";
+import { ResetProps } from "@/pages/ResetPasswordPage";
+import { JoinProps } from "@/pages/JoinPage";
+import { httpClient } from "@/api/http";
 
 export const join = async (userData: JoinProps) => {
   try {

--- a/src/api/carts.api.ts
+++ b/src/api/carts.api.ts
@@ -1,7 +1,7 @@
-import { Cart } from "../models/cart.model";
-import { httpClient } from "./http";
+import { Cart } from "@/models/cart.model";
+import { httpClient } from "@/api/http";
 
-interface addToCartParams {
+export interface addToCartParams {
   bookId: number;
   quantity: number;
 }

--- a/src/api/category.api.ts
+++ b/src/api/category.api.ts
@@ -1,12 +1,12 @@
 import { Category } from "../models/category.model";
 import { httpClient } from "./http";
 
-interface ApiResponse {
+interface CategoryResponse {
   categories: Category[];
   message?: string;
 }
 
 export const fetchCategory = async () => {
-  const res = await httpClient.get<ApiResponse>("/categories");
+  const res = await httpClient.get<CategoryResponse>("/categories");
   return res.data;
 };

--- a/src/api/queryClient.ts
+++ b/src/api/queryClient.ts
@@ -1,0 +1,3 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient();

--- a/src/api/review.api.ts
+++ b/src/api/review.api.ts
@@ -1,7 +1,17 @@
 import { httpClient } from "@/api/http";
-import { BookReviewItem } from "@/models/book.model";
+import { BookReviewItem, BookReviewItemWrite } from "@/models/book.model";
 
 export const fetchBookReview = async (bookId: string) => {
   const { data } = await httpClient.get<BookReviewItem[]>(`/reviews/${bookId}`);
+  return data;
+};
+
+export interface addBookReviewRequest {
+  bookId: string;
+  reviewData: BookReviewItemWrite;
+}
+
+export const addBookReview = async (bookId: string, reviewData: BookReviewItemWrite) => {
+  const { data } = await httpClient.post(`/reviews/${bookId}`, reviewData);
   return data;
 };

--- a/src/api/review.api.ts
+++ b/src/api/review.api.ts
@@ -1,0 +1,6 @@
+import { httpClient } from "@/api/http";
+import { BookReviewItem } from "@/models/book.model";
+
+export const fetchBookReview = async (bookId: string) => {
+  return await httpClient.get<BookReviewItem>(`/reviews/${bookId}`);
+};

--- a/src/api/review.api.ts
+++ b/src/api/review.api.ts
@@ -2,5 +2,6 @@ import { httpClient } from "@/api/http";
 import { BookReviewItem } from "@/models/book.model";
 
 export const fetchBookReview = async (bookId: string) => {
-  return await httpClient.get<BookReviewItem>(`/reviews/${bookId}`);
+  const { data } = await httpClient.get<BookReviewItem[]>(`/reviews/${bookId}`);
+  return data;
 };

--- a/src/components/book/AddBookReview.tsx
+++ b/src/components/book/AddBookReview.tsx
@@ -1,0 +1,116 @@
+import { useBookDetail } from "@/hooks/useBookDetail";
+import styled from "styled-components";
+import Button from "@/components/common/Button";
+import { useForm } from "react-hook-form";
+import { BookReviewItem, BookReviewItemWrite } from "@/models/book.model";
+import React, { useRef } from "react";
+import { getUserName } from "@/store/authStore";
+
+interface Props {
+  bookId: string;
+  children: React.ReactNode;
+  toggleReviewButton: () => void;
+}
+
+const AddBookReview = ({ children, toggleReviewButton, bookId }: Props) => {
+  const refId = useRef(8);
+
+  const { addReview } = useBookDetail(bookId);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<BookReviewItemWrite>();
+
+  const handleReview = (data: BookReviewItemWrite) => {
+    const mockData: BookReviewItem = {
+      id: refId.current++,
+      userName: getUserName() as string,
+      review: data.review,
+      createdAt: new Date().toISOString(),
+      score: data.score,
+    };
+    addReview({ bookId, reviewData: mockData });
+    toggleReviewButton();
+  };
+
+  return (
+    <AddBookReviewStyle>
+      <form onSubmit={handleSubmit(handleReview)}>
+        <fieldset>
+          <textarea
+            placeholder="내용을 입력해 주세요."
+            {...register("review", {
+              required: { value: true, message: "리뷰 내용을 작성해주세요" },
+            })}
+          ></textarea>
+          {errors.review && <small className="error-msg">{errors.review.message}</small>}
+        </fieldset>
+        <div className="sub-content">
+          <fieldset>
+            <select
+              {...register("score", { required: true, valueAsNumber: true })}
+              defaultValue={5}
+            >
+              <option value="5">5점</option>
+              <option value="4">4점</option>
+              <option value="3">3점</option>
+              <option value="2">2점</option>
+              <option value="1">1점</option>
+            </select>
+          </fieldset>
+          <fieldset>
+            <Button size="medium" scheme="primary">
+              작성 완료
+            </Button>
+          </fieldset>
+          <fieldset>{children}</fieldset>
+        </div>
+      </form>
+    </AddBookReviewStyle>
+  );
+};
+
+const AddBookReviewStyle = styled.div`
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    fieldset {
+      border: 0;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      justify-content: end;
+    }
+
+    textarea {
+      width: 100%;
+      height: 10rem;
+      resize: none;
+      border-radius: ${({ theme }) => theme.borderRadius.default};
+      border: 1px solid ${({ theme }) => theme.color.border};
+    }
+    .error-msg {
+      color: red;
+      font-size: 1rem;
+    }
+
+    .sub-content {
+      display: flex;
+      gap: 0.5rem;
+      justify-content: flex-end;
+      align-items: center;
+
+      select {
+        padding: 0.5rem;
+        font-size: 1.25rem;
+      }
+    }
+  }
+`;
+
+export default AddBookReview;

--- a/src/components/book/AddToCart.tsx
+++ b/src/components/book/AddToCart.tsx
@@ -1,10 +1,12 @@
 import styled from "styled-components";
-import InputText from "../common/InputText";
-import Button from "../common/Button";
+import InputText from "@/components/common/InputText";
+import Button from "@/components/common/Button";
 import { useState } from "react";
-import { BookDetail } from "../../models/book.model";
-import { Link } from "react-router-dom";
-import { useBookDetail } from "../../hooks/useBookDetail";
+import { BookDetail } from "@/models/book.model";
+import { Link, useNavigate } from "react-router-dom";
+import { useBookDetail } from "@/hooks/useBookDetail";
+import { useAlert } from "@/hooks/useAlert";
+import { useAuthStore } from "@/store/authStore";
 
 interface Props {
   book: BookDetail;
@@ -13,9 +15,21 @@ interface Props {
 const AddToCart = ({ book }: Props) => {
   const [quantity, setQuantity] = useState<number>(1);
   const { addToCart, isAddToCart } = useBookDetail(book.id.toString());
+  const { isLoggedIn } = useAuthStore();
+  const { showConfirm } = useAlert();
+  const navigate = useNavigate();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setQuantity(Number(e.target.value));
+  };
+
+  const handleAddToCart = () => {
+    if (!isLoggedIn) {
+      showConfirm("로그인이 필요합니다. 로그인 후 이용해주세요.", () => navigate("/login"));
+      return;
+    }
+
+    addToCart({ bookId: book.id, quantity });
   };
 
   const handleIncrease = () => {
@@ -37,13 +51,7 @@ const AddToCart = ({ book }: Props) => {
           -
         </Button>
       </div>
-      <Button
-        size="medium"
-        scheme="primary"
-        onClick={() => {
-          addToCart(quantity);
-        }}
-      >
+      <Button size="medium" scheme="primary" onClick={handleAddToCart}>
         장바구니에 담기
       </Button>
       <div className="add-message">

--- a/src/components/book/BookReview.tsx
+++ b/src/components/book/BookReview.tsx
@@ -1,17 +1,51 @@
 import styled from "styled-components";
 import BookReviewItem from "@/components/book/BookReviewItem";
 import { BookReviewItem as IBookReviewItem } from "@/models/book.model";
+import AddBookReview from "@/components/book/AddBookReview";
+import Button from "@/components/common/Button";
+import { useState } from "react";
 
 interface Props {
   reviews: IBookReviewItem[];
+  bookId: string;
 }
 
-const BookReview = ({ reviews }: Props) => {
+interface ReviewButtonProps {
+  isClicked: boolean;
+  handleClick: () => void;
+}
+
+const ReviewButton = ({ isClicked, handleClick }: ReviewButtonProps) => {
+  return (
+    <div className="review-btn">
+      <Button size="medium" scheme="primary" onClick={handleClick}>
+        {isClicked ? "취소" : "리뷰 쓰기"}
+      </Button>
+    </div>
+  );
+};
+
+const BookReview = ({ reviews, bookId }: Props) => {
+  const [isClicked, setIsClicked] = useState<boolean>(false);
+  const handleClick = () => {
+    setIsClicked((prev) => !prev);
+  };
+
   return (
     <BookReviewStyle>
-      {reviews.map((review) => (
-        <BookReviewItem key={review.id} review={review} />
-      ))}
+      {!isClicked && <ReviewButton isClicked={isClicked} handleClick={handleClick} />}
+
+      {isClicked && (
+        <AddBookReview bookId={bookId} toggleReviewButton={handleClick}>
+          <ReviewButton isClicked={isClicked} handleClick={handleClick} />
+        </AddBookReview>
+      )}
+      {reviews
+        .slice()
+        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+        .map((review) => (
+          <BookReviewItem key={review.id} review={review} />
+        ))}
     </BookReviewStyle>
   );
 };
@@ -21,6 +55,10 @@ const BookReviewStyle = styled.div`
   flex-direction: column;
   gap: 1.2rem;
   margin: 1.2rem 0;
+
+  .review-btn {
+    align-self: flex-end;
+  }
 `;
 
 export default BookReview;

--- a/src/components/book/BookReview.tsx
+++ b/src/components/book/BookReview.tsx
@@ -1,0 +1,26 @@
+import styled from "styled-components";
+import BookReviewItem from "@/components/book/BookReviewItem";
+import { BookReviewItem as IBookReviewItem } from "@/models/book.model";
+
+interface Props {
+  reviews: IBookReviewItem[];
+}
+
+const BookReview = ({ reviews }: Props) => {
+  return (
+    <BookReviewStyle>
+      {reviews.map((review) => (
+        <BookReviewItem key={review.id} review={review} />
+      ))}
+    </BookReviewStyle>
+  );
+};
+
+const BookReviewStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  margin: 1.2rem 0;
+`;
+
+export default BookReview;

--- a/src/components/book/BookReviewItem.tsx
+++ b/src/components/book/BookReviewItem.tsx
@@ -1,0 +1,76 @@
+import { BookReviewItem as IBookReviewItem } from "@/models/book.model";
+import { formatDate } from "@/utils/format";
+import styled from "styled-components";
+import { FaStar } from "@react-icons/all-files/fa/FaStar";
+
+interface Props {
+  review: IBookReviewItem;
+}
+
+const Star = ({ score }: Pick<IBookReviewItem, "score">) => {
+  return (
+    <span className="star">
+      {Array.from({ length: score }, (_, i) => (
+        <span key={i}>
+          <FaStar />
+        </span>
+      ))}
+    </span>
+  );
+};
+
+const BookReviewItem = ({ review }: Props) => {
+  return (
+    <BookReviewItemStyle>
+      <header className="header">
+        <div className="name-score-container">
+          <span className="name">{review.userName}</span>
+          <Star score={review.score} />
+        </div>
+        <div className="date-container">
+          <span className="date">{formatDate(review.createdAt)}</span>
+        </div>
+      </header>
+      <div className="content">
+        <p>{review.review}</p>
+      </div>
+    </BookReviewItemStyle>
+  );
+};
+
+const BookReviewItemStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  padding: 1rem;
+  box-shadow: ${({ theme }) => theme.borderShadow.itemShadow};
+  border-radius: ${({ theme }) => theme.borderRadius.default};
+
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 1.1rem;
+    padding: 0;
+
+    .name-score-container {
+      display: flex;
+      gap: 1rem;
+    }
+
+    .star {
+      svg {
+        fill: #ff7b00;
+      }
+    }
+  }
+
+  .content {
+    padding: 0;
+    p {
+      margin: 0;
+    }
+  }
+`;
+
+export default BookReviewItem;

--- a/src/components/books/BookItem.tsx
+++ b/src/components/books/BookItem.tsx
@@ -18,17 +18,17 @@ const BookItem = ({ book, view }: Props) => {
         <div className="book-img">
           <img src={getImgSrc(Number(book.imgUrl))} alt={book.title} />
         </div>
-        <div className="contents">
-          <h2 className="title">{book.title}</h2>
-          <p className="summary"> {book.summary}</p>
-          <p className="author"> {book.author}</p>
-          <p className="price"> {formatNumber(book.price)}원</p>
-          <button className="likes">
-            <GoHeart />
-            <span>{book.likes}</span>
-          </button>
-        </div>
       </Link>
+      <div className="contents">
+        <h2 className="title">{book.title}</h2>
+        <p className="summary"> {book.summary}</p>
+        <p className="author"> {book.author}</p>
+        <p className="price"> {formatNumber(book.price)}원</p>
+        <button className="likes">
+          <GoHeart />
+          <span>{book.likes}</span>
+        </button>
+      </div>
     </BookItemStyle>
   );
 };
@@ -37,12 +37,12 @@ const BookItemStyle = styled.section<Pick<Props, "view">>`
   display: flex;
   flex-direction: ${({ view }) => (view === "grid" ? "column" : "row")};
   box-shadow: ${({ theme }) => theme.borderShadow.itemShadow};
-  /* min-width: ${({ view }) => (view === "grid" ? "150px" : "")}; */
+  border-radius: ${({ theme }) => theme.borderRadius.default};
 
   .book-img {
     border-radius: ${({ theme }) => theme.borderRadius.default};
     overflow: hidden;
-    max-width: ${({ view }) => (view === "grid" ? "auto" : "200px")};
+    max-width: ${({ view }) => (view === "grid" ? "auto" : "180px")};
 
     img {
       max-width: 100%;

--- a/src/components/books/BooksFilter.tsx
+++ b/src/components/books/BooksFilter.tsx
@@ -1,12 +1,17 @@
 import styled from "styled-components";
-import { useCategory } from "../../hooks/useCategory";
-import Button from "../common/Button";
+import { useCategory } from "@/hooks/useCategory";
+import Button from "@/components/common/Button";
 import { useSearchParams } from "react-router-dom";
-import { QUERYSTRING } from "../../constants/querystring";
+import { QUERYSTRING } from "@/constants/querystring";
+import Loading from "@/components/common/Loading";
 
 const BooksFilter = () => {
-  const { category } = useCategory();
+  const { categories, isCategoriesLoading } = useCategory();
   const [searchParams, setSearchParams] = useSearchParams();
+
+  if (isCategoriesLoading || !categories) {
+    return <Loading />;
+  }
 
   const resetClickedPage = (newSearchParams: URLSearchParams) => {
     newSearchParams.set(QUERYSTRING.PAGE, "1");
@@ -35,7 +40,7 @@ const BooksFilter = () => {
   return (
     <BooksFilterStyle>
       <div className="category">
-        {category.map((item) => (
+        {categories.map((item) => (
           <Button
             size="medium"
             scheme={item.isActive ? "primary" : "normal"}

--- a/src/components/books/BooksList.tsx
+++ b/src/components/books/BooksList.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
-import { Book } from "../../models/book.model";
-import BookItem from "./BookItem";
+import { Book } from "@/models/book.model";
+import BookItem from "@/components/books/BookItem";
 import { useLocation } from "react-router-dom";
-import { QUERYSTRING } from "../../constants/querystring";
-import { ViewMode } from "./BooksViewSwitcher";
+import { QUERYSTRING } from "@/constants/querystring";
+import { ViewMode } from "@/components/books/BooksViewSwitcher";
 
 interface Props {
   books: Book[];
@@ -39,7 +39,8 @@ interface BookListStyleProps {
 
 const BooksListStyle = styled.section<BookListStyleProps>`
   display: grid;
-  grid-template-columns: ${({ view }) => (view === "grid" ? "repeat(4, 1fr)" : "repeat(1, 1fr)")};
+  grid-template-columns: ${({ view }) =>
+    view === "grid" ? "repeat(auto-fill, minmax(180px, auto))" : "repeat(1, 1fr)"};
   gap: 24px;
 `;
 

--- a/src/components/books/BooksViewSwitcher.tsx
+++ b/src/components/books/BooksViewSwitcher.tsx
@@ -57,7 +57,7 @@ const BooksViewSwitcherStyle = styled.div`
   gap: 4px;
 
   button {
-    padding: 8px;
+    padding: 0.5rem;
   }
 `;
 

--- a/src/components/category/ListModal.tsx
+++ b/src/components/category/ListModal.tsx
@@ -1,9 +1,13 @@
 import { Link } from "react-router-dom";
 import styled from "styled-components";
-import { useCategory } from "../../hooks/useCategory";
+import { useCategory } from "@/hooks/useCategory";
 
 const ListModal = () => {
-  const { category } = useCategory();
+  const { categories, isCategoriesLoading } = useCategory();
+
+  if (isCategoriesLoading || !categories) {
+    return null;
+  }
 
   return (
     <ListModalStyle>
@@ -11,7 +15,7 @@ const ListModal = () => {
         <div className="rhombus"></div>
         <ul>
           <h2>도서 카테고리</h2>
-          {category.map((item) => {
+          {categories.map((item) => {
             return (
               <li key={item.categoryId}>
                 <Link
@@ -55,7 +59,6 @@ const ListModalStyle = styled.div`
     gap: 0.5rem;
     height: 100%;
     width: 100%;
-    /* border-radius: ${({ theme }) => theme.borderRadius.default}; */
   }
 
   .rhombus::before {

--- a/src/components/common/EllipsisBox.tsx
+++ b/src/components/common/EllipsisBox.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
-import Button from "./Button";
+import Button from "@/components/common/Button";
 import { FaAngleDown } from "@react-icons/all-files/fa/FaAngleDown";
 
 interface Props {
@@ -21,7 +21,7 @@ const EllipsisBox = ({ children, line }: Props) => {
 
       // 컴포넌트가 마운트될 때 실제 텍스트의 줄 수를 계산
       const textHeight = textRef.current?.clientHeight ?? 1; // 상세 설명이 차지하는 요소의 높이
-      console.log(textHeight, Math.round(textHeight / (fontSize * 1.5)));
+      // console.log(textHeight, Math.round(textHeight / (fontSize * 1.5)));
       return Math.round(textHeight / (fontSize * 1.5));
     }
     return 1;

--- a/src/components/common/Loading.tsx
+++ b/src/components/common/Loading.tsx
@@ -1,0 +1,33 @@
+import styled from "styled-components";
+import { FaSpinner } from "@react-icons/all-files/fa/FaSpinner";
+
+const Loading = () => {
+  return (
+    <LoadingStyle>
+      <FaSpinner />
+    </LoadingStyle>
+  );
+};
+
+const LoadingStyle = styled.div`
+  padding: 30rem;
+  text-align: center;
+
+  @keyframes rotate {
+    0% {
+      transform: rotate(0);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+
+  svg {
+    width: 70px;
+    height: 70px;
+    fill: #ececec;
+    animation: rotate 1s cubic-bezier(0.06, 0.08, 0.1, 1) infinite;
+  }
+`;
+
+export default Loading;

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -1,0 +1,3 @@
+export const queryKey = {
+  books: "books",
+};

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -1,3 +1,5 @@
 export const queryKey = {
   books: "books",
+  categories: "categories",
+  carts: "carts",
 };

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -2,4 +2,5 @@ export const queryKey = {
   books: "books",
   categories: "categories",
   carts: "carts",
+  bookDetail: "bookDetail",
 };

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -3,5 +3,6 @@ export const queryKey = {
   categories: "categories",
   carts: "carts",
   bookDetail: "bookDetail",
+  bookReview: "bookReview",
   orderList: "orderList",
 };

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -3,4 +3,5 @@ export const queryKey = {
   categories: "categories",
   carts: "carts",
   bookDetail: "bookDetail",
+  orderList: "orderList",
 };

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -4,12 +4,12 @@ import { LoginProps } from "@/pages/LoginPage";
 import { useAuthStore } from "@/store/authStore";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useAlert } from "./useAlert";
+import { useAlert } from "@/hooks/useAlert";
 import { ResetProps } from "@/pages/ResetPasswordPage";
 
 export const useAuth = () => {
   // 상태
-  const { isLoggedIn, storeLogin, storeLogout } = useAuthStore();
+  const { storeLogin } = useAuthStore();
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [resetRequested, setResetRequested] = useState(false);
   const { showAlert } = useAlert();
@@ -31,7 +31,7 @@ export const useAuth = () => {
   const userLogin = async (data: LoginProps) => {
     try {
       const { id, email, name, contact, accessToken } = await login(data);
-      storeLogin(accessToken);
+      storeLogin(accessToken, name);
       setErrorMsg(null);
       navigate("/");
     } catch (err: any) {

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,78 @@
+import { join, login, resetPassword, resetPasswordRequest } from "@/api/auth.api";
+import { JoinProps } from "@/pages/JoinPage";
+import { LoginProps } from "@/pages/LoginPage";
+import { useAuthStore } from "@/store/authStore";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAlert } from "./useAlert";
+import { ResetProps } from "@/pages/ResetPasswordPage";
+
+export const useAuth = () => {
+  // 상태
+  const { isLoggedIn, storeLogin, storeLogout } = useAuthStore();
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [resetRequested, setResetRequested] = useState(false);
+  const { showAlert } = useAlert();
+  const navigate = useNavigate();
+
+  // 메서드
+  const userJoin = async (data: JoinProps) => {
+    try {
+      const { message } = await join(data);
+      setErrorMsg(null);
+      showAlert(message);
+      navigate("/login");
+    } catch (err: any) {
+      const { message: errMsg } = err.response.data;
+      setErrorMsg(errMsg);
+    }
+  };
+
+  const userLogin = async (data: LoginProps) => {
+    try {
+      const { id, email, name, contact, accessToken } = await login(data);
+      storeLogin(accessToken);
+      setErrorMsg(null);
+      navigate("/");
+    } catch (err: any) {
+      const { message: errMsg } = err.response.data;
+      setErrorMsg(errMsg);
+    }
+  };
+
+  const userResetPasswordRequest = async (data: ResetProps) => {
+    // 비밀번호 초기화 요청(가입한 이메일 확인과정)
+    try {
+      await resetPasswordRequest(data);
+      setResetRequested(true);
+      setErrorMsg(null);
+    } catch (err: any) {
+      const { message: errMsg } = err.response.data;
+      setErrorMsg(errMsg);
+    }
+  };
+
+  const userResetPassword = async (data: ResetProps) => {
+    try {
+      // 비밀번호 초기화(비밀번호 변경과정)
+      const { message } = await resetPassword(data);
+      showAlert(message);
+      setResetRequested(false);
+      setErrorMsg(null);
+      navigate("/login");
+    } catch (err: any) {
+      const { message: errMsg } = err.response.data;
+      setErrorMsg(errMsg);
+    }
+  };
+
+  // return
+  return {
+    errorMsg,
+    resetRequested,
+    userJoin,
+    userLogin,
+    userResetPassword,
+    userResetPasswordRequest,
+  };
+};

--- a/src/hooks/useBookDetail.ts
+++ b/src/hooks/useBookDetail.ts
@@ -3,6 +3,7 @@ import { fetchDetailBooks, toggleLikeBook } from "@/api/books.api";
 import { addToCartParams, requestAddToCart } from "@/api/carts.api";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { queryKey } from "@/constants/queryKey";
+import { fetchBookReview } from "@/api/review.api";
 
 export const useBookDetail = (bookId: string | undefined) => {
   const [isAddToCart, setIsAddToCart] = useState<boolean>(false);
@@ -10,6 +11,11 @@ export const useBookDetail = (bookId: string | undefined) => {
   const { data: bookDetail, isLoading: isBookDetailLoading } = useQuery({
     queryKey: [queryKey.bookDetail, bookId],
     queryFn: () => (bookId && Number(bookId) ? fetchDetailBooks(bookId) : Promise.resolve(null)),
+  });
+
+  const { data: bookReview, isLoading: isBookReviewLoading } = useQuery({
+    queryKey: [queryKey.bookReview, bookId],
+    queryFn: () => (bookId ? fetchBookReview(bookId) : Promise.resolve(null)),
   });
 
   const { mutate: addToCart } = useMutation({
@@ -41,5 +47,13 @@ export const useBookDetail = (bookId: string | undefined) => {
     },
   });
 
-  return { bookDetail, isBookDetailLoading, toggleLike, addToCart, isAddToCart };
+  return {
+    bookDetail,
+    isBookDetailLoading,
+    toggleLike,
+    addToCart,
+    isAddToCart,
+    bookReview,
+    isBookReviewLoading,
+  };
 };

--- a/src/hooks/useBookDetail.ts
+++ b/src/hooks/useBookDetail.ts
@@ -1,66 +1,45 @@
-import { useNavigate } from "react-router-dom";
-import { useEffect, useState } from "react";
-import { FetchToggleBookLike, fetchDetailBooks, toggleLikeBook } from "../api/books.api";
-import { BookDetail } from "../models/book.model";
-import { useAuthStore } from "../store/authStore";
-import { requestAddToCart } from "../api/carts.api";
-import { useAlert } from "./useAlert";
+import { useState } from "react";
+import { fetchDetailBooks, toggleLikeBook } from "@/api/books.api";
+import { addToCartParams, requestAddToCart } from "@/api/carts.api";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { queryKey } from "@/constants/queryKey";
 
 export const useBookDetail = (bookId: string | undefined) => {
-  const [bookDetail, setBookDetail] = useState<BookDetail | null>(null);
   const [isAddToCart, setIsAddToCart] = useState<boolean>(false);
-  const { isLoggedIn } = useAuthStore();
-  const navigate = useNavigate();
-  const { showConfirm } = useAlert();
 
-  const addToCart = async (quantity: number) => {
-    if (!isLoggedIn) {
-      showConfirm("로그인이 필요합니다. 로그인 후 이용해주세요.", () => navigate("/login"));
-      return;
-    }
+  const { data: bookDetail, isLoading: isBookDetailLoading } = useQuery({
+    queryKey: [queryKey.bookDetail, bookId],
+    queryFn: () => (bookId && Number(bookId) ? fetchDetailBooks(bookId) : Promise.resolve(null)),
+  });
 
-    if (!bookDetail) return;
+  const { mutate: addToCart } = useMutation({
+    mutationFn: ({ bookId, quantity }: addToCartParams) => requestAddToCart({ bookId, quantity }),
+    onSuccess: () => {
+      setIsAddToCart(true);
+      setTimeout(() => {
+        setIsAddToCart(false);
+      }, 3000);
+    },
+  });
 
-    await requestAddToCart({ bookId: bookDetail.id, quantity });
-    setIsAddToCart(true);
-    setTimeout(() => {
-      setIsAddToCart(false);
-    }, 3000);
-  };
+  const queryClient = useQueryClient();
 
-  const toggleLike = () => {
-    // 로그인하지 않은 사용자의 좋아요 버튼 클릭 시, 서버로 요청 보내지 않고 프론트에서 선처리
-    if (!isLoggedIn) {
-      showConfirm("로그인이 필요합니다. 로그인 후 이용해주세요.", () => navigate("/login"));
-      return;
-    }
-
-    if (!bookDetail) return;
-
-    toggleLikeBook(bookDetail.id).then((res: FetchToggleBookLike) => {
-      const { likes, message } = res;
-      if (message === "liked") {
-        setBookDetail({
+  const { mutate: toggleLike } = useMutation({
+    mutationFn: async (bookId: number) => {
+      const { likes, message } = await toggleLikeBook(bookId);
+      return { likes, message };
+    },
+    onSuccess: ({ likes, message }) => {
+      if (bookDetail) {
+        const updatedBookDetail = {
           ...bookDetail,
           likes: likes,
-          isLiked: true,
-        });
-      } else {
-        setBookDetail({
-          ...bookDetail,
-          likes: likes,
-          isLiked: false,
-        });
+          isLiked: message === "liked",
+        };
+        queryClient.setQueryData([queryKey.bookDetail, bookId], updatedBookDetail);
       }
-    });
-  };
+    },
+  });
 
-  useEffect(() => {
-    if (!bookId) return;
-
-    fetchDetailBooks(bookId).then((res: BookDetail) => {
-      setBookDetail(res);
-    });
-  }, [bookId]);
-  return { bookDetail, toggleLike, addToCart, isAddToCart };
+  return { bookDetail, isBookDetailLoading, toggleLike, addToCart, isAddToCart };
 };

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -19,6 +19,7 @@ export const useBooks = () => {
   const { data: booksData, isLoading: isBooksLoading } = useQuery({
     queryKey: [queryKey.books, params],
     queryFn: () => fetchBooks(params),
+    staleTime: 1000 * 60 * 60,
   });
 
   return {

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -2,6 +2,7 @@ import { useLocation } from "react-router-dom";
 import { fetchBooks } from "@/api/books.api";
 import { LIMIT, QUERYSTRING } from "@/constants/querystring";
 import { useQuery } from "@tanstack/react-query";
+import { queryKey } from "@/constants/queryKey";
 
 export const useBooks = () => {
   const location = useLocation();
@@ -16,7 +17,7 @@ export const useBooks = () => {
   };
 
   const { data: booksData, isLoading: isBooksLoading } = useQuery({
-    queryKey: ["books", location.search],
+    queryKey: [queryKey.books, params],
     queryFn: () => fetchBooks(params),
   });
 

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -1,36 +1,30 @@
-import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
-import { Book } from "../models/book.model";
-import { Pagination } from "../models/pagination.model";
-import { FetchBooksResponse, fetchBooks } from "../api/books.api";
-import { LIMIT, QUERYSTRING } from "../constants/querystring";
+import { fetchBooks } from "@/api/books.api";
+import { LIMIT, QUERYSTRING } from "@/constants/querystring";
+import { useQuery } from "@tanstack/react-query";
 
 export const useBooks = () => {
   const location = useLocation();
-  const [books, setBooks] = useState<Book[]>([]);
-  const [pagination, setPagination] = useState<Pagination>({ totalBooks: 0, page: 1 });
-  const [isEmpty, setIsEmpty] = useState<boolean>(true);
-  const [message, setMessage] = useState<string | null>("");
+  const searchParams = new URLSearchParams(location.search);
+  const params = {
+    category_id: searchParams.get(QUERYSTRING.CATEGORY_ID)
+      ? Number(searchParams.get(QUERYSTRING.CATEGORY_ID))
+      : undefined,
+    new: searchParams.get(QUERYSTRING.NEW) ? true : undefined,
+    page: searchParams.get(QUERYSTRING.PAGE) ? Number(searchParams.get(QUERYSTRING.PAGE)) : 1,
+    limit: LIMIT,
+  };
 
-  useEffect(() => {
-    const searchParams = new URLSearchParams(location.search);
-    const params = {
-      category_id: searchParams.get(QUERYSTRING.CATEGORY_ID)
-        ? Number(searchParams.get(QUERYSTRING.CATEGORY_ID))
-        : undefined,
-      new: searchParams.get(QUERYSTRING.NEW) ? true : undefined,
-      page: searchParams.get(QUERYSTRING.PAGE) ? Number(searchParams.get(QUERYSTRING.PAGE)) : 1,
-      limit: LIMIT,
-    };
+  const { data: booksData, isLoading: isBooksLoading } = useQuery({
+    queryKey: ["books", location.search],
+    queryFn: () => fetchBooks(params),
+  });
 
-    fetchBooks(params).then((res: FetchBooksResponse) => {
-      const { books, pagination, message } = res;
-      setBooks(books);
-      setPagination(pagination);
-      setIsEmpty(books.length === 0);
-      setMessage(message);
-    });
-  }, [location.search]);
-
-  return { books, pagination, isEmpty, message };
+  return {
+    books: booksData?.books,
+    pagination: booksData?.pagination,
+    isEmpty: booksData?.books.length === 0,
+    message: booksData?.message,
+    isBooksLoading,
+  };
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,9 @@ import App from "./App";
 async function mountApp() {
   if (process.env.NODE_ENV === "development") {
     const { worker } = require("./mock/browser");
-    await worker.start(); // MSW 시작
+    await worker.start({
+      onUnhandledRequest: "bypass",
+    }); // MSW 시작
   }
 
   const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,18 @@
-import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 
-const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
-root.render(
-  // <React.StrictMode>
-  <App />,
-  // </React.StrictMode>,
-);
+async function mountApp() {
+  if (process.env.NODE_ENV === "development") {
+    const { worker } = require("./mock/browser");
+    await worker.start(); // MSW 시작
+  }
+
+  const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
+  root.render(
+    // <React.StrictMode>
+    <App />,
+    // </React.StrictMode>,
+  );
+}
+
+mountApp();

--- a/src/mock/browser.ts
+++ b/src/mock/browser.ts
@@ -1,7 +1,7 @@
 import { setupWorker } from "msw/browser";
-import { reviewsById } from "./review";
+import { addReview, reviewsById } from "./review";
 
-const handlers = [reviewsById];
+const handlers = [reviewsById, addReview];
 
 // 서비스 워커 생성
 export const worker = setupWorker(...handlers);

--- a/src/mock/browser.ts
+++ b/src/mock/browser.ts
@@ -1,0 +1,7 @@
+import { setupWorker } from "msw/browser";
+import { reviewsById } from "./review";
+
+const handlers = [reviewsById];
+
+// 서비스 워커 생성
+export const worker = setupWorker(...handlers);

--- a/src/mock/review.ts
+++ b/src/mock/review.ts
@@ -1,0 +1,17 @@
+import { BookReviewItem } from "@/models/book.model";
+import { HttpResponse, http } from "msw";
+import { fakerKO as faker } from "@faker-js/faker";
+
+// faker api 사용
+const mockReviewData: BookReviewItem[] = Array.from({ length: 8 }, (_, i) => ({
+  id: i,
+  userName: `${faker.person.lastName()}${faker.person.firstName()}`,
+  review: faker.lorem.paragraph(),
+  createdAt: faker.date.past().toISOString(),
+  score: faker.helpers.rangeToNumber({ min: 1, max: 5 }),
+}));
+
+// 핸들러 작성
+export const reviewsById = http.get(`${process.env.REACT_APP_BASE_URL}/reviews/:bookId`, () => {
+  return HttpResponse.json(mockReviewData, { status: 200 });
+});

--- a/src/mock/review.ts
+++ b/src/mock/review.ts
@@ -15,3 +15,11 @@ const mockReviewData: BookReviewItem[] = Array.from({ length: 8 }, (_, i) => ({
 export const reviewsById = http.get(`${process.env.REACT_APP_BASE_URL}/reviews/:bookId`, () => {
   return HttpResponse.json(mockReviewData, { status: 200 });
 });
+
+export const addReview = http.post(
+  `${process.env.REACT_APP_BASE_URL}/reviews/:bookId`,
+  async ({ request }) => {
+    const reviewData = await request.json();
+    return HttpResponse.json({ message: "리뷰가 등록되었습니다.", reviewData }, { status: 200 });
+  },
+);

--- a/src/models/book.model.ts
+++ b/src/models/book.model.ts
@@ -19,3 +19,11 @@ export interface BookDetail extends Book {
   isLiked: boolean;
   categoryName: string;
 }
+
+export interface BookReviewItem {
+  id: number;
+  userName: string;
+  review: string;
+  createdAt: string;
+  score: number;
+}

--- a/src/models/book.model.ts
+++ b/src/models/book.model.ts
@@ -27,3 +27,5 @@ export interface BookReviewItem {
   createdAt: string;
   score: number;
 }
+
+export type BookReviewItemWrite = Pick<BookReviewItem, "review" | "score">;

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -38,7 +38,8 @@ const BookDetailPage = () => {
   const { isLoggedIn } = useAuthStore();
   const { showConfirm } = useAlert();
   const navigate = useNavigate();
-  const { bookDetail, toggleLike, isBookDetailLoading } = useBookDetail(bookId);
+  const { bookDetail, toggleLike, isBookDetailLoading, bookReview, isBookReviewLoading } =
+    useBookDetail(bookId);
 
   if (!bookId) return <Error />;
   if (isBookDetailLoading) return <Loading />;

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -1,14 +1,14 @@
 import { useParams } from "react-router-dom";
 import styled from "styled-components";
-import { useBookDetail } from "../hooks/useBookDetail";
-import { getImgSrc } from "../utils/image";
-import Title from "../components/common/Title";
-import { BookDetail } from "../models/book.model";
-import { formatDate, formatNumber } from "../utils/format";
+import { useBookDetail } from "@/hooks/useBookDetail";
+import { getImgSrc } from "@/utils/image";
+import Title from "@/components/common/Title";
+import { BookDetail } from "@/models/book.model";
+import { formatDate, formatNumber } from "@/utils/format";
 import { Link } from "react-router-dom";
-import EllipsisBox from "../components/common/EllipsisBox";
-import LikeButton from "../components/book/LikeButton";
-import AddToCart from "../components/book/AddToCart";
+import EllipsisBox from "@/components/common/EllipsisBox";
+import LikeButton from "@/components/book/LikeButton";
+import AddToCart from "@/components/book/AddToCart";
 
 const bookInfoList = [
   {
@@ -39,7 +39,6 @@ const BookDetailPage = () => {
 
   if (!bookDetail) return null;
 
-  // console.log(bookDetail);
   return (
     <BookDetailPageStyle>
       <header>

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import styled from "styled-components";
 import { useBookDetail } from "@/hooks/useBookDetail";
 import { getImgSrc } from "@/utils/image";
@@ -9,6 +9,10 @@ import { Link } from "react-router-dom";
 import EllipsisBox from "@/components/common/EllipsisBox";
 import LikeButton from "@/components/book/LikeButton";
 import AddToCart from "@/components/book/AddToCart";
+import { useAlert } from "@/hooks/useAlert";
+import { useAuthStore } from "@/store/authStore";
+import Error from "@/components/common/Error";
+import Loading from "@/components/common/Loading";
 
 const bookInfoList = [
   {
@@ -31,13 +35,23 @@ const bookInfoList = [
 
 const BookDetailPage = () => {
   const { bookId } = useParams();
-  const { bookDetail, toggleLike } = useBookDetail(bookId);
+  const { isLoggedIn } = useAuthStore();
+  const { showConfirm } = useAlert();
+  const navigate = useNavigate();
+  const { bookDetail, toggleLike, isBookDetailLoading } = useBookDetail(bookId);
+
+  if (!bookId) return <Error />;
+  if (isBookDetailLoading) return <Loading />;
+  if (!bookDetail) return <Error />;
 
   const handleClickLike = () => {
-    toggleLike();
-  };
+    if (!isLoggedIn) {
+      showConfirm("로그인이 필요합니다. 로그인 후 이용해주세요.", () => navigate("/login"));
+      return;
+    }
 
-  if (!bookDetail) return null;
+    toggleLike(+bookId);
+  };
 
   return (
     <BookDetailPageStyle>

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -13,6 +13,7 @@ import { useAlert } from "@/hooks/useAlert";
 import { useAuthStore } from "@/store/authStore";
 import Error from "@/components/common/Error";
 import Loading from "@/components/common/Loading";
+import BookReview from "@/components/book/BookReview";
 
 const bookInfoList = [
   {
@@ -42,8 +43,8 @@ const BookDetailPage = () => {
     useBookDetail(bookId);
 
   if (!bookId) return <Error />;
-  if (isBookDetailLoading) return <Loading />;
-  if (!bookDetail) return <Error />;
+  if (isBookDetailLoading || isBookReviewLoading) return <Loading />;
+  if (!bookDetail || !bookReview) return <Error />;
 
   const handleClickLike = () => {
     if (!isLoggedIn) {
@@ -80,10 +81,18 @@ const BookDetailPage = () => {
         </div>
       </header>
       <section className="contents">
-        <Title size="medium">상세 설명</Title>
-        <EllipsisBox line={7}>{bookDetail.detail}</EllipsisBox>
-        <Title size="medium">목차</Title>
-        <p className="index">{bookDetail.contents}</p>
+        <div>
+          <Title size="medium">상세 설명</Title>
+          <EllipsisBox line={7}>{bookDetail.detail}</EllipsisBox>
+        </div>
+        <div>
+          <Title size="medium">목차</Title>
+          <p className="index">{bookDetail.contents}</p>
+        </div>
+        <div>
+          <Title size="medium">{`리뷰(${bookReview.length})`}</Title>
+          <BookReview reviews={bookReview} />
+        </div>
       </section>
     </BookDetailPageStyle>
   );
@@ -144,6 +153,12 @@ const BookDetailPageStyle = styled.section`
   p {
     font-size: 1.3rem;
     margin: 1.2rem 0;
+  }
+
+  .contents {
+    display: flex;
+    flex-direction: column;
+    gap: 1.7rem;
   }
 `;
 

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -91,7 +91,7 @@ const BookDetailPage = () => {
         </div>
         <div>
           <Title size="medium">{`리뷰(${bookReview.length})`}</Title>
-          <BookReview reviews={bookReview} />
+          <BookReview reviews={bookReview} bookId={bookId} />
         </div>
       </section>
     </BookDetailPageStyle>

--- a/src/pages/BooksPage.tsx
+++ b/src/pages/BooksPage.tsx
@@ -1,16 +1,33 @@
-import Title from "../components/common/Title";
+import Title from "@/components/common/Title";
 import styled from "styled-components";
-import BooksFilter from "../components/books/BooksFilter";
-import BooksList from "../components/books/BooksList";
-import Page from "../components/books/Page";
-import BooksViewSwitcher from "../components/books/BooksViewSwitcher";
-import { useBooks } from "../hooks/useBooks";
-import Empty from "../components/common/Empty";
+import BooksFilter from "@/components/books/BooksFilter";
+import BooksList from "@/components/books/BooksList";
+import Page from "@/components/books/Page";
+import BooksViewSwitcher from "@/components/books/BooksViewSwitcher";
+import { useBooks } from "@/hooks/useBooks";
+import Empty from "@/components/common/Empty";
 import { FaRegGrinBeamSweat } from "@react-icons/all-files/fa/FaRegGrinBeamSweat";
 import { HiCursorClick } from "@react-icons/all-files/hi/HiCursorClick";
+import Loading from "@/components/common/Loading";
 
 const BooksPage = () => {
-  const { books, pagination, isEmpty, message } = useBooks();
+  const { books, pagination, isEmpty, message, isBooksLoading } = useBooks();
+
+  // if (isEmpty) {
+  //   return (
+  //     <Empty
+  //       icon={<FaRegGrinBeamSweat />}
+  //       linkIcon={<HiCursorClick />}
+  //       title={message as string}
+  //       link="/"
+  //       linkMsg="메인 화면으로 가기"
+  //     />
+  //   );
+  // }
+
+  if (isBooksLoading || !books || !pagination) {
+    return <Loading />;
+  }
 
   return (
     <BooksStyle>
@@ -20,7 +37,7 @@ const BooksPage = () => {
         <BooksFilter />
         <BooksViewSwitcher />
       </div>
-      {isEmpty ? (
+      {isEmpty && (
         <Empty
           icon={<FaRegGrinBeamSweat />}
           linkIcon={<HiCursorClick />}
@@ -28,7 +45,8 @@ const BooksPage = () => {
           link="/"
           linkMsg="메인 화면으로 가기"
         />
-      ) : (
+      )}
+      {!isEmpty && (
         <>
           <BooksList books={books} />
           <Page pagination={pagination} />

--- a/src/pages/BooksPage.tsx
+++ b/src/pages/BooksPage.tsx
@@ -13,18 +13,6 @@ import Loading from "@/components/common/Loading";
 const BooksPage = () => {
   const { books, pagination, isEmpty, message, isBooksLoading } = useBooks();
 
-  // if (isEmpty) {
-  //   return (
-  //     <Empty
-  //       icon={<FaRegGrinBeamSweat />}
-  //       linkIcon={<HiCursorClick />}
-  //       title={message as string}
-  //       link="/"
-  //       linkMsg="메인 화면으로 가기"
-  //     />
-  //   );
-  // }
-
   if (isBooksLoading || !books || !pagination) {
     return <Loading />;
   }

--- a/src/pages/CartPage.tsx
+++ b/src/pages/CartPage.tsx
@@ -1,15 +1,15 @@
 import styled from "styled-components";
-import Title from "../components/common/Title";
-import { useCarts } from "../hooks/useCarts";
+import Title from "@/components/common/Title";
+import { useCarts } from "@/hooks/useCarts";
 import { useMemo, useState } from "react";
-import Empty from "../components/common/Empty";
+import Empty from "@/components/common/Empty";
 import { IoCartOutline } from "@react-icons/all-files/io5/IoCartOutline";
 import { FaBook } from "@react-icons/all-files/fa/FaBook";
-import CartSummary from "../components/carts/CartSummary";
-import Button from "../components/common/Button";
-import { useAlert } from "../hooks/useAlert";
-import { CartItem, Order } from "../models/order.model";
-import CartItemComponent from "../components/carts/CartItem";
+import CartSummary from "@/components/carts/CartSummary";
+import Button from "@/components/common/Button";
+import { useAlert } from "@/hooks/useAlert";
+import { CartItem, Order } from "@/models/order.model";
+import CartItemComponent from "@/components/carts/CartItem";
 import { useNavigate } from "react-router-dom";
 
 const CartPage = () => {

--- a/src/pages/CartPage.tsx
+++ b/src/pages/CartPage.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import Title from "@/components/common/Title";
 import { useCarts } from "@/hooks/useCarts";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import Empty from "@/components/common/Empty";
 import { IoCartOutline } from "@react-icons/all-files/io5/IoCartOutline";
 import { FaBook } from "@react-icons/all-files/fa/FaBook";
@@ -11,12 +11,31 @@ import { useAlert } from "@/hooks/useAlert";
 import { CartItem, Order } from "@/models/order.model";
 import CartItemComponent from "@/components/carts/CartItem";
 import { useNavigate } from "react-router-dom";
+import Loading from "@/components/common/Loading";
 
 const CartPage = () => {
-  const { carts, isEmpty, message, deletedCartItem } = useCarts();
+  const { carts, isEmpty, message, isCartsLoading, deletedCartItem } = useCarts();
   const [selectedItems, setSelectedItems] = useState<number[]>([]);
   const { showAlert } = useAlert();
   const navigate = useNavigate();
+
+  if (isCartsLoading || !carts) {
+    return <Loading />;
+  }
+
+  const totalQuantity = carts?.reduce((acc, item) => {
+    if (selectedItems.includes(item.cartItemId)) {
+      return acc + item.quantity;
+    }
+    return acc;
+  }, 0);
+
+  const totalPrice = carts?.reduce((acc, item) => {
+    if (selectedItems.includes(item.cartItemId)) {
+      return acc + item.price * item.quantity;
+    }
+    return acc;
+  }, 0);
 
   const handleSelected = (id: number) => {
     if (selectedItems.includes(id)) {
@@ -28,8 +47,8 @@ const CartPage = () => {
     }
   };
 
-  const handleDeleted = async (id: number) => {
-    await deletedCartItem(id);
+  const handleDeleted = (id: number) => {
+    deletedCartItem(id);
   };
 
   const handleOrder = () => {
@@ -40,14 +59,14 @@ const CartPage = () => {
 
     // 주문서 작성 페이지로 이동하기 전에 주문서 작성할 때 필요한 데이터를 넘겨줌(배송지 정보는 제외)
     const orderItems: CartItem[] = carts
-      .filter((item) => selectedItems.includes(item.cartItemId))
+      ?.filter((item) => selectedItems.includes(item.cartItemId))
       .map((item) => ({
         cartItemId: item.cartItemId,
         bookId: item.bookId,
         quantity: item.quantity,
       }));
 
-    const mainBookTitle = carts.find(({ cartItemId }) => cartItemId === selectedItems[0])
+    const mainBookTitle = carts?.find(({ cartItemId }) => cartItemId === selectedItems[0])
       ?.title as string;
 
     const orderData: Omit<Order, "delivery"> = {
@@ -59,24 +78,6 @@ const CartPage = () => {
 
     navigate("/orders", { state: orderData });
   };
-
-  const totalQuantity = useMemo(() => {
-    return carts.reduce((acc, item) => {
-      if (selectedItems.includes(item.cartItemId)) {
-        return acc + item.quantity;
-      }
-      return acc;
-    }, 0);
-  }, [selectedItems, carts]);
-
-  const totalPrice = useMemo(() => {
-    return carts.reduce((acc, item) => {
-      if (selectedItems.includes(item.cartItemId)) {
-        return acc + item.price * item.quantity;
-      }
-      return acc;
-    }, 0);
-  }, [selectedItems, carts]);
 
   return (
     <CartPageStyle>

--- a/src/pages/JoinPage.tsx
+++ b/src/pages/JoinPage.tsx
@@ -1,20 +1,20 @@
 import styled from "styled-components";
-import Title from "../components/common/Title";
-import InputText from "../components/common/InputText";
-import Button from "../components/common/Button";
-import { Link, useNavigate } from "react-router-dom";
+import Title from "@/components/common/Title";
+import InputText from "@/components/common/InputText";
+import Button from "@/components/common/Button";
+import { Link } from "react-router-dom";
 import { FaWhmcs } from "@react-icons/all-files/fa/FaWhmcs";
 import { FaSignInAlt } from "@react-icons/all-files/fa/FaSignInAlt";
 import { useForm } from "react-hook-form";
-import { join } from "../api/auth.api";
-import { useState } from "react";
-import { useAlert } from "../hooks/useAlert";
+import { useAuth } from "@/hooks/useAuth";
 import {
   emailOptions,
   passwordOptions,
   contactOptions,
   nameOptions,
-} from "../config/registerOptions";
+} from "@/config/registerOptions";
+import { useState } from "react";
+
 export interface JoinProps {
   email: string;
   password: string;
@@ -23,32 +23,23 @@ export interface JoinProps {
 }
 
 const JoinPage = () => {
+  const { userJoin, errorMsg } = useAuth();
+  const [lastEmail, setLastEmail] = useState<string>("");
   const {
     register,
     handleSubmit,
     formState: { errors },
   } = useForm<JoinProps>();
 
-  const [emailCheck, setEmailCheck] = useState("");
-  const navigate = useNavigate();
-  const { showAlert } = useAlert();
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.value !== emailCheck) {
-      setEmailCheck("");
+  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.value !== lastEmail) {
+      setLastEmail("");
     }
   };
 
   const onSubmit = async (data: JoinProps) => {
-    try {
-      const { message } = await join(data);
-      setEmailCheck("");
-      showAlert(message);
-      navigate("/login");
-    } catch (err: any) {
-      const { message: errMsg } = err.response.data;
-      setEmailCheck(errMsg);
-    }
+    await userJoin(data);
+    setLastEmail(data.email);
   };
 
   return (
@@ -69,14 +60,11 @@ const JoinPage = () => {
             <InputText
               placeholder="가입할 이메일을 입력해주세요."
               type="text"
-              $isError={errors.email || (!errors.email && emailCheck) ? true : false}
-              {...register("email", {
-                ...emailOptions,
-                onChange: handleChange,
-              })}
+              $isError={errors.email || (!errors.email && lastEmail) ? true : false}
+              {...register("email", { ...emailOptions, onChange: handleOnChange })}
             />
             {errors.email && <small className="error-text">{errors.email.message}</small>}
-            {!errors.email && emailCheck && <small className="error-text">{emailCheck}</small>}
+            {!errors.email && lastEmail && <small className="error-text">{errorMsg}</small>}
           </fieldset>
           <fieldset>
             <InputText

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,15 +1,13 @@
-import Title from "../components/common/Title";
-import InputText from "../components/common/InputText";
-import Button from "../components/common/Button";
-import { Link, useNavigate } from "react-router-dom";
+import Title from "@/components/common/Title";
+import InputText from "@/components/common/InputText";
+import Button from "@/components/common/Button";
+import { Link } from "react-router-dom";
 import { FaRegUser } from "@react-icons/all-files/fa/FaRegUser";
 import { FaWhmcs } from "@react-icons/all-files/fa/FaWhmcs";
 import { useForm } from "react-hook-form";
-import { login } from "../api/auth.api";
-import { useState } from "react";
-import { JoinPageStyle } from "./JoinPage";
-import { useAuthStore } from "../store/authStore";
-import { emailOptions, passwordOptions } from "../config/registerOptions";
+import { JoinPageStyle } from "@/pages/JoinPage";
+import { emailOptions, passwordOptions } from "@/config/registerOptions";
+import { useAuth } from "@/hooks/useAuth";
 
 export interface LoginProps {
   email: string;
@@ -17,33 +15,15 @@ export interface LoginProps {
 }
 
 const LoginPage = () => {
+  const { errorMsg, userLogin } = useAuth();
   const {
     register,
     handleSubmit,
     formState: { errors },
   } = useForm<LoginProps>();
 
-  const [loginCheckMsg, setLoginCheckMsg] = useState("");
-  const { storeLogin } = useAuthStore();
-
-  const navigate = useNavigate();
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.value !== loginCheckMsg) {
-      setLoginCheckMsg("");
-    }
-  };
-
   const onSubmit = async (data: LoginProps) => {
-    try {
-      const { id, email, name, contact, accessToken } = await login(data);
-      storeLogin(accessToken);
-      setLoginCheckMsg("");
-      navigate("/");
-    } catch (err: any) {
-      const { message: errMsg } = err.response.data;
-      setLoginCheckMsg(errMsg);
-    }
+    await userLogin(data);
   };
 
   return (
@@ -55,26 +35,25 @@ const LoginPage = () => {
             <InputText
               placeholder="이메일을 입력해주세요."
               type="email"
-              $isError={errors.email ? true : false}
-              {...register("email", {
-                ...emailOptions,
-                onChange: handleChange,
-              })}
+              $isError={!errorMsg && errors.email ? true : false}
+              {...register("email", emailOptions)}
             />
-            {errors.email && <small className="error-text">{errors.email.message}</small>}
+            {!errorMsg && errors.email && (
+              <small className="error-text">{errors.email.message}</small>
+            )}
           </fieldset>
           <fieldset>
             <InputText
               placeholder="비밀번호를 입력해주세요."
               type="password"
-              $isError={errors.password ? true : false}
-              {...register("password", { ...passwordOptions, onChange: handleChange })}
+              $isError={!errorMsg && errors.password ? true : false}
+              {...register("password", passwordOptions)}
             />
-            {errors.password && <small className="error-text">{errors.password.message}</small>}
+            {!errorMsg && errors.password && (
+              <small className="error-text">{errors.password.message}</small>
+            )}
           </fieldset>
-          {!errors.email && !errors.password && loginCheckMsg && (
-            <small className="error-text">{loginCheckMsg}</small>
-          )}
+          {errorMsg && <small className="error-text">{errorMsg}</small>}
 
           <fieldset>
             <Button type="submit" size="medium" scheme="primary">

--- a/src/pages/OrderList.tsx
+++ b/src/pages/OrderList.tsx
@@ -1,16 +1,15 @@
 import React, { useState } from "react";
 import styled from "styled-components";
-import Title from "../components/common/Title";
-import { useOrders } from "../hooks/useOrders";
-import { formatDate, formatNumber } from "../utils/format";
-import Button from "../components/common/Button";
-import OrderItemDetail from "../components/order/OrderItemDetail";
+import Title from "@/components/common/Title";
+import { useOrders } from "@/hooks/useOrders";
+import { formatDate, formatNumber } from "@/utils/format";
+import Button from "@/components/common/Button";
+import OrderItemDetail from "@/components/order/OrderItemDetail";
 
 const OrderListPage = () => {
   const { orderList, selectedOrderId, getOrderDetail } = useOrders();
   const [clickOrderId, setClickOrderId] = useState<number | null>(null);
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  console.log(orderList);
 
   const handleDetailButton = async (orderId: number) => {
     await getOrderDetail(orderId);

--- a/src/pages/OrderPage.tsx
+++ b/src/pages/OrderPage.tsx
@@ -1,15 +1,15 @@
 import { useLocation, useNavigate } from "react-router-dom";
 import styled from "styled-components";
-import InputText from "../components/common/InputText";
+import InputText from "@/components/common/InputText";
 import { useForm } from "react-hook-form";
-import Title from "../components/common/Title";
-import CartSummary from "../components/carts/CartSummary";
-import Button from "../components/common/Button";
-import { CartPageStyle } from "./CartPage";
-import { Delivery, Order } from "../models/order.model";
-import { useAlert } from "../hooks/useAlert";
-import FindAddressButton from "../components/order/FindAddressButton";
-import { requestOrder } from "../api/order.api";
+import Title from "@/components/common/Title";
+import CartSummary from "@/components/carts/CartSummary";
+import Button from "@/components/common/Button";
+import { CartPageStyle } from "@/pages/CartPage";
+import { Delivery, Order } from "@/models/order.model";
+import { useAlert } from "@/hooks/useAlert";
+import FindAddressButton from "@/components/order/FindAddressButton";
+import { requestOrder } from "@/api/order.api";
 
 interface DeliveryProps extends Delivery {
   detailAddress: string;

--- a/src/pages/OrderPage.tsx
+++ b/src/pages/OrderPage.tsx
@@ -62,7 +62,9 @@ const OrderPage = () => {
               주문 상품
             </Title>
             <strong>
-              {mainBookTitle} 외 총 {totalQuantity}권
+              {orderDataFromCart.items.length > 0
+                ? `${mainBookTitle} 외 총 ${totalQuantity}권`
+                : `${mainBookTitle} 총 ${totalQuantity}권`}
             </strong>
           </div>
           <section className="order-info">

--- a/src/routers/router.jsx
+++ b/src/routers/router.jsx
@@ -1,92 +1,65 @@
 import { createBrowserRouter } from "react-router-dom";
-import Error from "../components/common/Error";
-import HomePage from "../pages/HomePage";
-import Layout from "../components/layout/Layout";
-import JoinPage from "../pages/JoinPage";
-import ResetPasswordPage from "../pages/ResetPasswordPage";
-import LoginPage from "../pages/LoginPage";
-import BooksPage from "../pages/BooksPage";
-import BookDetailPage from "../pages/BookDetailPage";
-import CartPage from "../pages/CartPage";
-import OrderPage from "../pages/OrderPage";
-import OrderListPage from "../pages/OrderList";
+import Error from "@/components/common/Error";
+import HomePage from "@/pages/HomePage";
+import Layout from "@/components/layout/Layout";
+import JoinPage from "@/pages/JoinPage";
+import ResetPasswordPage from "@/pages/ResetPasswordPage";
+import LoginPage from "@/pages/LoginPage";
+import BooksPage from "@/pages/BooksPage";
+import BookDetailPage from "@/pages/BookDetailPage";
+import CartPage from "@/pages/CartPage";
+import OrderPage from "@/pages/OrderPage";
+import OrderListPage from "@/pages/OrderList";
 
-export const router = createBrowserRouter([
+const preRouterList = [
   {
     path: "/",
-    element: (
-      <Layout>
-        <HomePage />
-      </Layout>
-    ),
+    element: <HomePage />,
+  },
+  {
+    path: "/join",
+    element: <JoinPage />,
+  },
+  {
+    path: "/login",
+    element: <LoginPage />,
+  },
+  {
+    path: "/reset",
+    element: <ResetPasswordPage />,
+  },
+  {
+    path: "/books",
+    element: <BooksPage />,
+  },
+  {
+    path: "/books/:bookId",
+    element: <BookDetailPage />,
+  },
+  {
+    path: "/carts",
+    element: <CartPage />,
+  },
+  {
+    path: "/orders",
+    element: <OrderPage />,
+  },
+  {
+    path: "/orderlist",
+    element: <OrderListPage />,
+  },
+];
+
+const routerList = preRouterList.map((item) => {
+  return {
+    ...item,
+    element: <Layout>{item.element}</Layout>,
     errorElement: (
       <Layout>
         <Error />
       </Layout>
     ),
-  },
-  {
-    path: "/join",
-    element: (
-      <Layout>
-        <JoinPage />
-      </Layout>
-    ),
-  },
-  {
-    path: "/login",
-    element: (
-      <Layout>
-        <LoginPage />
-      </Layout>
-    ),
-  },
-  {
-    path: "/reset",
-    element: (
-      <Layout>
-        <ResetPasswordPage />
-      </Layout>
-    ),
-  },
-  {
-    path: "/books",
-    element: (
-      <Layout>
-        <BooksPage />
-      </Layout>
-    ),
-  },
-  {
-    path: "/books/:bookId",
-    element: (
-      <Layout>
-        <BookDetailPage />
-      </Layout>
-    ),
-  },
-  {
-    path: "/carts",
-    element: (
-      <Layout>
-        <CartPage />
-      </Layout>
-    ),
-  },
-  {
-    path: "/orders",
-    element: (
-      <Layout>
-        <OrderPage />
-      </Layout>
-    ),
-  },
-  {
-    path: "/orderlist",
-    element: (
-      <Layout>
-        <OrderListPage />
-      </Layout>
-    ),
-  },
-]);
+  };
+});
+
+export const router = createBrowserRouter(routerList);

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,17 +1,27 @@
 import { create } from "zustand";
+
 // interface UserInfo {
-//   id: number;
-//   name: string;
-//   email: string;
-//   contact:string;
+//   // id?: number;
+//   name: string | null;
+//   // email?: string;
+//   // contact?:string;
 // }
 
 interface StoreState {
-  // userInfo: UserInfo;
+  userName: string | null;
   isLoggedIn: boolean; // 상태 변수(state)
-  storeLogin: (token: string) => void; // 상태 변경 함수(action)
+  storeLogin: (token: string, name: string) => void; // 상태 변경 함수(action)
   storeLogout: () => void;
 }
+
+export const getUserName = () => {
+  const userName = localStorage.getItem("userName");
+  return userName;
+};
+
+export const setUserName = (name: string) => {
+  localStorage.setItem("userName", name);
+};
 
 export const getToken = () => {
   const token = localStorage.getItem("token");
@@ -26,14 +36,21 @@ export const removeToken = () => {
   localStorage.removeItem("token");
 };
 
+export const removeUserName = () => {
+  localStorage.removeItem("userName");
+};
+
 export const useAuthStore = create<StoreState>((set) => ({
+  userName: getToken() ? getUserName() : null,
   isLoggedIn: getToken() ? true : false, // 초기값 설정
-  storeLogin: (token: string) => {
+  storeLogin: (token: string, name: string) => {
     set({ isLoggedIn: true });
     setToken(token);
+    setUserName(name);
   },
   storeLogout: () => {
     set({ isLoggedIn: false });
     removeToken();
+    removeUserName();
   },
 }));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -20,7 +16,6 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "extends": "./tsconfig.paths.json",
+  "include": ["src", "craco.config.js"]
 }

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
+}


### PR DESCRIPTION
## 생성 컴포넌트 및 추가된 기능
- 도서 상세 페이지에서 보여질 리뷰 목록 컴포넌트(BookReview) 생성
  - reviewsById 핸들러 : msw를 이용한 리뷰 조회 기능 api를 생성하고 서비스 워커 핸들러로 등록
  - 리뷰 목록 조회 요청 시, faker api를 이용하여 고정된 리뷰 데이터(mock data)를 만들어서 모킹 응답으로 전달
- 리뷰 등록 기능 추가 
  -  addReview 핸들러 : msw를 이용한 리뷰 등록 기능 api를 생성하고 서비스 워커 핸들러로 등록
  - 리뷰 등록 요청이 들어올 경우, 사용자가 작성한 리뷰데이터(reviewData)를 body에서 추출하여 모킹 응답에 담아서 전달 ⇒ bookReview 쿼리 키로 관리중인 캐시 데이터에 추가하기 위해(단, 새로운 리뷰 데이터는 영구적인 저장은 아님)


## 리팩토링
- craco 라이브러리와 react-app-alias를 사용하여 별칭을 이용한 절대경로로 변경
- useAuth 커스텀 훅 :  로그인 및 회원가입, 비밀번호 초기화와 같은 인증 관련 요청을 다루는 커스텀 훅 생성
- TanStack Query를 사용하여 서버 데이터 관리 & react-query dev tool도 함께 사용
  - useBooks, useDetailBook, useCategoty, useCarts 훅에 적용
  - 추후 useAuth, useOrders  커스텀 훅에도 적용할 예정