### PR TITLE
[feat]: 메인화면 구현, 모바일 대응/[fix]: 장바구니 선택 오류 해결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,9 @@
         "react-hook-form": "^7.50.1",
         "react-router-dom": "^6.22.1",
         "react-scripts": "5.0.1",
+        "react-slick": "^0.30.2",
         "sanitize.css": "^13.0.0",
+        "slick-carousel": "^1.8.1",
         "styled-components": "^6.1.8",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4",
@@ -36,6 +38,7 @@
       "devDependencies": {
         "@craco/craco": "^7.1.0",
         "@faker-js/faker": "^8.4.1",
+        "@types/react-slick": "^0.23.13",
         "msw": "^2.2.3",
         "react-app-alias": "^2.2.2"
       }
@@ -4680,6 +4683,15 @@
         "@types/react-router": "*"
       }
     },
+    "node_modules/@types/react-slick": {
+      "version": "0.23.13",
+      "resolved": "https://registry.npmjs.org/@types/react-slick/-/react-slick-0.23.13.tgz",
+      "integrity": "sha512-bNZfDhe/L8t5OQzIyhrRhBr/61pfBcWaYJoq6UDqFtv5LMwfg4NsVDD2J8N01JqdAdxLjOt66OZEp6PX+dGs/A==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -6375,6 +6387,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
+    },
     "node_modules/clean-css": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
@@ -7609,6 +7626,11 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/enquire.js": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/enquire.js/-/enquire.js-2.1.6.tgz",
+      "integrity": "sha512-/KujNpO+PT63F7Hlpu4h3pE3TokKRHN26JYmQpPyjkRD/N57R7bPDNojMXdi7uveAKjYB7yQnartCxZnFWr0Xw=="
     },
     "node_modules/entities": {
       "version": "2.2.0",
@@ -12495,6 +12517,12 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "peer": true
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -12592,6 +12620,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
+    },
+    "node_modules/json2mq": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+      "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+      "dependencies": {
+        "string-convert": "^0.2.0"
+      }
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -15752,6 +15788,22 @@
         }
       }
     },
+    "node_modules/react-slick": {
+      "version": "0.30.2",
+      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.30.2.tgz",
+      "integrity": "sha512-XvQJi7mRHuiU3b9irsqS9SGIgftIfdV5/tNcURTb5LdIokRA5kIIx3l4rlq2XYHfxcSntXapoRg/GxaVOM1yfg==",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "enquire.js": "^2.1.6",
+        "json2mq": "^0.2.0",
+        "lodash.debounce": "^4.0.8",
+        "resize-observer-polyfill": "^1.5.0"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -15953,6 +16005,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -16623,6 +16680,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/slick-carousel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
+      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==",
+      "peerDependencies": {
+        "jquery": ">=1.8.0"
+      }
+    },
     "node_modules/sockjs": {
       "version": "0.3.24",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
@@ -16885,6 +16950,11 @@
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
+    },
+    "node_modules/string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A=="
     },
     "node_modules/string-length": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "react-hook-form": "^7.50.1",
     "react-router-dom": "^6.22.1",
     "react-scripts": "5.0.1",
+    "react-slick": "^0.30.2",
     "sanitize.css": "^13.0.0",
+    "slick-carousel": "^1.8.1",
     "styled-components": "^6.1.8",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4",
@@ -56,6 +58,7 @@
   "devDependencies": {
     "@craco/craco": "^7.1.0",
     "@faker-js/faker": "^8.4.1",
+    "@types/react-slick": "^0.23.13",
     "msw": "^2.2.3",
     "react-app-alias": "^2.2.2"
   },

--- a/src/api/banner.api.ts
+++ b/src/api/banner.api.ts
@@ -1,0 +1,11 @@
+import { Banner } from "@/models/banner.model";
+import { httpClient } from "./http";
+
+export const fetchBanners = async () => {
+  try {
+    const { data } = await httpClient.get<Banner[]>(`/banners`);
+    return data;
+  } catch (err: any) {
+    throw err;
+  }
+};

--- a/src/api/books.api.ts
+++ b/src/api/books.api.ts
@@ -54,3 +54,12 @@ export const toggleLikeBook = async (bookId: number) => {
     throw err;
   }
 };
+
+export const fetchBestBooks = async () => {
+  try {
+    const res = await httpClient.get<Book[]>(`/books/best`);
+    return res.data;
+  } catch (err: any) {
+    throw err;
+  }
+};

--- a/src/api/carts.api.ts
+++ b/src/api/carts.api.ts
@@ -15,7 +15,7 @@ export const requestAddToCart = async (params: addToCartParams) => {
   }
 };
 
-interface FetchAllCartResponse {
+export interface FetchAllCartResponse {
   items: Cart[];
   message: string | null;
 }

--- a/src/api/review.api.ts
+++ b/src/api/review.api.ts
@@ -15,3 +15,8 @@ export const addBookReview = async (bookId: string, reviewData: BookReviewItemWr
   const { data } = await httpClient.post(`/reviews/${bookId}`, reviewData);
   return data;
 };
+
+export const fetchReviewsAll = async () => {
+  const { data } = await httpClient.get<BookReviewItem[]>(`/reviews/`);
+  return data;
+};

--- a/src/components/book/AddToCart.tsx
+++ b/src/components/book/AddToCart.tsx
@@ -14,7 +14,7 @@ interface Props {
 
 const AddToCart = ({ book }: Props) => {
   const [quantity, setQuantity] = useState<number>(1);
-  const { addToCart, isAddToCart } = useBookDetail(book.id.toString());
+  const { addToCart, isAddToCart, message } = useBookDetail(book.id.toString());
   const { isLoggedIn } = useAuthStore();
   const { showConfirm } = useAlert();
   const navigate = useNavigate();
@@ -55,7 +55,7 @@ const AddToCart = ({ book }: Props) => {
         장바구니에 담기
       </Button>
       <div className="add-message">
-        <p>장바구니에 추가되었습니다.</p>
+        <p>{message}</p>
         <Link to="/carts">보러가기</Link>
       </div>
     </AddToCartStyle>
@@ -101,12 +101,13 @@ const AddToCartStyle = styled.div<AddToCartStyleProps>`
     transition: all 0.5s ease;
 
     p {
-      color: ${({ theme }) => theme.color};
+      color: ${({ theme }) => theme.color.text};
     }
 
     a {
       font-weight: 600;
       font-size: 1.3rem;
+      color: ${({ theme }) => theme.color.third};
     }
   }
 `;

--- a/src/components/book/AddToCart.tsx
+++ b/src/components/book/AddToCart.tsx
@@ -76,20 +76,24 @@ const AddToCartStyle = styled.div<AddToCartStyleProps>`
   .count {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-start;
     flex-wrap: nowrap;
     gap: 0.1rem;
+    height: 100%;
 
     input {
       text-align: center;
       outline: none;
-      padding: 0.5rem 1.5rem;
     }
+  }
+
+  button {
+    height: 100%;
   }
 
   .add-message {
     position: absolute;
-    top: 40%;
+    top: 50vmin;
     left: 50%;
     background-color: ${({ theme }) => theme.color.background};
     border-radius: ${({ theme }) => theme.borderRadius.default};
@@ -105,9 +109,26 @@ const AddToCartStyle = styled.div<AddToCartStyleProps>`
     }
 
     a {
-      font-weight: 600;
-      font-size: 1.3rem;
+      font-weight: 700;
       color: ${({ theme }) => theme.color.third};
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    a {
+      font-size: 2.2rem;
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    a {
+      font-size: 1.8rem;
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.desktop} {
+    a {
+      font-size: 1.6rem;
     }
   }
 `;

--- a/src/components/book/BookReviewItem.tsx
+++ b/src/components/book/BookReviewItem.tsx
@@ -51,7 +51,6 @@ const BookReviewItemStyle = styled.div`
     display: flex;
     justify-content: space-between;
     align-items: center;
-    font-size: 1.1rem;
     padding: 0;
 
     .name-score-container {
@@ -76,6 +75,33 @@ const BookReviewItemStyle = styled.div`
 
     p {
       margin: 0;
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    .header {
+      font-size: 2.3rem;
+    }
+    p {
+      font-size: 2rem;
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    .header {
+      font-size: 1.8rem;
+    }
+    p {
+      font-size: 1.6rem;
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.desktop} {
+    .header {
+      font-size: 1.6rem;
+    }
+    p {
+      font-size: 1.4rem;
     }
   }
 `;

--- a/src/components/book/BookReviewItem.tsx
+++ b/src/components/book/BookReviewItem.tsx
@@ -43,6 +43,7 @@ const BookReviewItemStyle = styled.div`
   flex-direction: column;
   gap: 1.2rem;
   padding: 1rem;
+  justify-content: space-between;
   box-shadow: ${({ theme }) => theme.borderShadow.itemShadow};
   border-radius: ${({ theme }) => theme.borderRadius.default};
 
@@ -55,6 +56,7 @@ const BookReviewItemStyle = styled.div`
 
     .name-score-container {
       display: flex;
+      flex-wrap: wrap;
       gap: 1rem;
     }
 
@@ -63,10 +65,15 @@ const BookReviewItemStyle = styled.div`
         fill: #ff7b00;
       }
     }
+
+    .date {
+      word-break: keep-all;
+    }
   }
 
   .content {
     padding: 0;
+
     p {
       margin: 0;
     }

--- a/src/components/book/LikeButton.tsx
+++ b/src/components/book/LikeButton.tsx
@@ -22,14 +22,23 @@ const LikeButton = ({ book, onClick }: Props) => {
 };
 
 const LikeButtonStyle = styled(Button)<Props>`
-  /* display: flex;
-  align-items: center;
-  gap: 6px; */
   color: ${({ book }) => (book.isLiked ? "red" : "inherit")};
   font-size: 1.5rem;
 
   svg {
     color: ${({ book }) => (book.isLiked ? "red" : "inherit")};
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    font-size: 2.2rem;
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    font-size: 1.8rem;
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.desktop} {
+    font-size: 1.6rem;
   }
 `;
 

--- a/src/components/books/BestBookItem.tsx
+++ b/src/components/books/BestBookItem.tsx
@@ -1,0 +1,65 @@
+import { Book } from "@/models/book.model";
+import styled from "styled-components";
+import BookItem, { BookItemStyle } from "./BookItem";
+
+interface Props {
+  book: Book;
+  itemIdx: number;
+}
+const BestBookItem = ({ book, itemIdx }: Props) => {
+  return (
+    <BestBookItemStyle>
+      <BookItem book={book} view="grid" isFake={true} />
+      <div className="rank">{itemIdx + 1}</div>
+    </BestBookItemStyle>
+  );
+};
+
+const BestBookItemStyle = styled.div`
+  ${BookItemStyle} {
+    height: 100%;
+
+    .summary,
+    .price,
+    .likes {
+      display: none;
+    }
+
+    h2 {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+    }
+
+    .contents {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+    }
+  }
+
+  position: relative;
+
+  .rank {
+    position: absolute;
+    top: -0.8rem;
+    left: -0.8rem;
+    width: 3rem;
+    height: 3rem;
+    background-color: ${({ theme }) => theme.color.third};
+    border-radius: 500px;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.25rem;
+    color: #fff;
+    font-weight: 700;
+    font-style: italic;
+  }
+`;
+
+export default BestBookItem;

--- a/src/components/books/BestBookItem.tsx
+++ b/src/components/books/BestBookItem.tsx
@@ -55,10 +55,26 @@ const BestBookItemStyle = styled.div`
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 1.25rem;
+    font-size: 2rem;
     color: #fff;
     font-weight: 700;
     font-style: italic;
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    .rank {
+      font-size: 3rem;
+      width: 5rem;
+      height: 5rem;
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    .rank {
+      font-size: 2.5rem;
+      width: 4rem;
+      height: 4rem;
+    }
   }
 `;
 

--- a/src/components/books/BookItem.tsx
+++ b/src/components/books/BookItem.tsx
@@ -8,17 +8,25 @@ import { Link } from "react-router-dom";
 
 interface Props {
   book: Book;
-  view: ViewMode;
+  isFake?: boolean;
+  view?: ViewMode;
 }
 
-const BookItem = ({ book, view }: Props) => {
+const BookItem = ({ book, view, isFake = false }: Props) => {
   return (
     <BookItemStyle view={view}>
-      <Link to={`/books/${book.id}`}>
+      {isFake ? (
         <div className="book-img">
           <img src={getImgSrc(Number(book.imgUrl))} alt={book.title} />
         </div>
-      </Link>
+      ) : (
+        <Link to={`/books/${book.id}`}>
+          <div className="book-img">
+            <img src={getImgSrc(Number(book.imgUrl))} alt={book.title} />
+          </div>
+        </Link>
+      )}
+
       <div className="contents">
         <h2 className="title">{book.title}</h2>
         <p className="summary"> {book.summary}</p>
@@ -33,7 +41,7 @@ const BookItem = ({ book, view }: Props) => {
   );
 };
 
-const BookItemStyle = styled.section<Pick<Props, "view">>`
+export const BookItemStyle = styled.section<Pick<Props, "view">>`
   display: flex;
   flex-direction: ${({ view }) => (view === "grid" ? "column" : "row")};
   box-shadow: ${({ theme }) => theme.borderShadow.itemShadow};
@@ -51,7 +59,7 @@ const BookItemStyle = styled.section<Pick<Props, "view">>`
   }
 
   .contents {
-    padding: 16px;
+    padding: 1.2rem;
     position: relative;
     flex: ${({ view }) => (view === "grid" ? "0" : "1")};
 

--- a/src/components/books/BookItem.tsx
+++ b/src/components/books/BookItem.tsx
@@ -5,6 +5,7 @@ import { formatNumber } from "../../utils/format";
 import { GoHeart } from "@react-icons/all-files/go/GoHeart";
 import { ViewMode } from "./BooksViewSwitcher";
 import { Link } from "react-router-dom";
+import Button from "../common/Button";
 
 interface Props {
   book: Book;
@@ -31,11 +32,13 @@ const BookItem = ({ book, view, isFake = false }: Props) => {
         <h2 className="title">{book.title}</h2>
         <p className="summary"> {book.summary}</p>
         <p className="author"> {book.author}</p>
-        <p className="price"> {formatNumber(book.price)}원</p>
-        <button className="likes">
-          <GoHeart />
-          <span>{book.likes}</span>
-        </button>
+        <div className="sub-contents">
+          <p className="price"> {formatNumber(book.price)}원</p>
+          <Button size="medium" scheme="primary">
+            <GoHeart />
+            {book.likes}
+          </Button>
+        </div>
       </div>
     </BookItemStyle>
   );
@@ -50,35 +53,36 @@ export const BookItemStyle = styled.section<Pick<Props, "view">>`
   .book-img {
     border-radius: ${({ theme }) => theme.borderRadius.default};
     overflow: hidden;
-    max-width: ${({ view }) => (view === "grid" ? "auto" : "180px")};
+    height: 100%;
 
     img {
-      max-width: 100%;
-      object-fit: fill;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
     }
   }
 
   .contents {
     padding: 1.2rem;
-    position: relative;
     flex: ${({ view }) => (view === "grid" ? "0" : "1")};
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: 1rem;
 
     .title {
-      font-size: 1.5rem;
       font-weight: 700;
-      margin: 0 0 12px 0;
+      /* margin: 0 0 12px 0; */
     }
 
     p {
-      font-size: 1rem;
       color: ${({ theme }) => theme.color.secondary};
-      margin: 0 0 4px 0;
+      /* margin: 0 0 4px 0; */
+      margin: 0;
     }
 
     .summary {
       line-height: 1.2;
-      height: calc(2 * 1.2 * 1.15rem); /* 2줄 * 상속받은 line-height(=1.5) * font-size(=0.75rem) */
-      font-size: 1.15rem;
 
       overflow: hidden;
       text-overflow: ellipsis;
@@ -86,31 +90,69 @@ export const BookItemStyle = styled.section<Pick<Props, "view">>`
       -webkit-line-clamp: 2; /* 보여질 줄의 갯수  */
       -webkit-box-orient: vertical;
     }
+  }
+
+  .sub-contents {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
 
     .price {
       font-weight: 700;
+      margin: 0;
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    .title {
+      font-size: 2.5rem;
+    }
+    p {
+      font-size: 2.3rem;
+    }
+    .summary {
+      height: calc(2 * 1.2 * 2.3rem);
+      font-size: 2.3rem;
     }
 
-    .likes {
-      font-size: 1rem;
-      font-weight: 700;
-      display: inline-flex;
-      align-items: center;
-      gap: 3px;
-      color: ${({ theme }) => theme.color.primary};
-      background-color: ${({ theme }) => theme.color.background};
-      border-radius: ${({ theme }) => theme.borderRadius.default};
-      border: 1px solid ${({ theme }) => theme.color.border};
-      padding: 4px 8px;
-      position: absolute;
-      bottom: 20px; // .contents의 padding-bottom과 동일한 값을 준다 => 가장 하단 요소인 .price의 높이와 동일하게 우측으로 배치하기 위해
-      right: 16px;
+    .book-img {
+      overflow: hidden;
+      max-width: ${({ view }) => (view === "grid" ? "auto" : "160px")};
     }
+  }
 
-    span {
-      font-size: 1rem;
-      font-weight: 700;
-      color: ${({ theme }) => theme.color.primary};
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    .title {
+      font-size: 2.3rem;
+    }
+    p {
+      font-size: 2rem;
+    }
+    .summary {
+      height: calc(2 * 1.2 * 2rem);
+      font-size: 2rem;
+    }
+    .book-img {
+      overflow: hidden;
+      max-width: ${({ view }) => (view === "grid" ? "auto" : "200px")};
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.desktop} {
+    .title {
+      font-size: 2rem;
+    }
+    p {
+      font-size: 1.6rem;
+    }
+    .summary {
+      height: calc(2 * 1.2 * 1.6rem);
+      font-size: 1.6rem;
+    }
+    .book-img {
+      overflow: hidden;
+      max-width: ${({ view }) => (view === "grid" ? "auto" : "220px")};
     }
   }
 `;

--- a/src/components/books/BooksFilter.tsx
+++ b/src/components/books/BooksFilter.tsx
@@ -66,7 +66,9 @@ const BooksFilter = () => {
 
 const BooksFilterStyle = styled.div`
   display: flex;
-  gap: 24px;
+  /* flex-direction: column; */
+  gap: 2rem;
+  margin-bottom: 10px;
 
   .category {
     display: flex;

--- a/src/components/books/BooksList.tsx
+++ b/src/components/books/BooksList.tsx
@@ -39,9 +39,21 @@ interface BookListStyleProps {
 
 const BooksListStyle = styled.section<BookListStyleProps>`
   display: grid;
-  grid-template-columns: ${({ view }) =>
-    view === "grid" ? "repeat(auto-fill, minmax(180px, auto))" : "repeat(1, 1fr)"};
-  gap: 24px;
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    grid-template-columns: ${({ view }) => (view === "grid" ? "repeat(2, 1fr)" : "repeat(1, 1fr)")};
+    gap: 2.5rem;
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    grid-template-columns: ${({ view }) => (view === "grid" ? "repeat(3, 1fr)" : "repeat(1, 1fr)")};
+    gap: 1.5rem;
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.desktop} {
+    grid-template-columns: ${({ view }) => (view === "grid" ? "repeat(4, 1fr)" : "repeat(1, 1fr)")};
+    gap: 1.8rem;
+  }
 `;
 
 export default BooksList;

--- a/src/components/books/BooksViewSwitcher.tsx
+++ b/src/components/books/BooksViewSwitcher.tsx
@@ -55,6 +55,7 @@ const BooksViewSwitcher = () => {
 const BooksViewSwitcherStyle = styled.div`
   display: flex;
   gap: 4px;
+  margin-bottom: 10px;
 
   button {
     padding: 0.5rem;

--- a/src/components/carts/CartItem.tsx
+++ b/src/components/carts/CartItem.tsx
@@ -46,7 +46,6 @@ const CartItem = ({ cart, selectedItems, onSelected, onDeleted }: CartsProps) =>
         </div>
         <div className="book-contents">
           <h1 className="title">{cart.title}</h1>
-          <p className="book-summary">{cart.summary}</p>
           <p className="price">{`${formatNumber(cart.price)}원`}</p>
           <p className="quantity">{cart.quantity}권</p>
         </div>
@@ -67,9 +66,15 @@ const CartItemStyle = styled.div`
   border: 1px solid ${({ theme }) => theme.color.border};
   border-radius: ${({ theme }) => theme.borderRadius.default};
   width: 100%;
+  height: 100%;
+
+  .title {
+    font-size: 1.8rem;
+  }
 
   p {
     margin: 0;
+    font-size: 1.5rem;
   }
 
   .book-img {
@@ -79,16 +84,11 @@ const CartItemStyle = styled.div`
       max-width: 130px;
       object-fit: fill;
     }
-
-    @media screen and (max-width: 600px) {
-      img {
-        max-width: 100px;
-      }
-    }
   }
 
   .check-content-container {
     width: 100%;
+    height: 100%;
     display: flex;
     align-items: flex-start;
     gap: 0.5rem;
@@ -96,11 +96,11 @@ const CartItemStyle = styled.div`
 
   .book-contents {
     width: 100%;
+    height: 100%;
     padding: 0 1rem;
-    /* flex-grow: 1; */
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    justify-content: space-between;
   }
 
   .book-summary {
@@ -122,6 +122,50 @@ const CartItemStyle = styled.div`
     svg {
       color: ${({ theme }) => theme.buttonScheme.normal.color};
       cursor: pointer;
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    .book-img {
+      img {
+        max-width: 100px;
+      }
+    }
+    .book-contents {
+      .title {
+        font-size: 2.5rem;
+      }
+      p {
+        font-size: 2.2rem;
+      }
+    }
+
+    .delete-btn {
+      width: 3rem;
+      height: 3rem;
+      svg {
+        width: 3rem;
+        height: 3rem;
+      }
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    .book-contents {
+      .title {
+        font-size: 2rem;
+      }
+      p {
+        font-size: 1.7rem;
+      }
+    }
+    .delete-btn {
+      width: 2.7rem;
+      height: 2.7rem;
+      svg {
+        width: 2.7rem;
+        height: 2.7rem;
+      }
     }
   }
 `;

--- a/src/components/carts/CartItem.tsx
+++ b/src/components/carts/CartItem.tsx
@@ -28,7 +28,13 @@ const CartItem = ({ cart, selectedItems, onSelected, onDeleted }: CartsProps) =>
   };
 
   const handleOnDelete = () => {
-    showConfirm("선택한 상품을 삭제하시겠어요?", () => onDeleted(cart.cartItemId));
+    showConfirm("선택한 상품을 삭제하시겠어요?", () => {
+      if (selectedItems.includes(cart.cartItemId)) {
+        // 체크표시 누른 상태에서 아이템 삭제 누른경우 -> selectedItems에서도 해당 아이템 제거해야함
+        onSelected(cart.cartItemId);
+      }
+      onDeleted(cart.cartItemId);
+    });
   };
 
   return (

--- a/src/components/carts/CartSummary.tsx
+++ b/src/components/carts/CartSummary.tsx
@@ -30,17 +30,38 @@ const CartSummaryStyle = styled.div`
 
   .title {
     margin-bottom: 1.5rem;
+    font-size: 2rem;
   }
 
   dl {
     display: flex;
     justify-content: space-between;
     margin-bottom: 0.8rem;
-    font-size: 1.2rem;
+    font-size: 1.4rem;
 
     dd {
       font-weight: 700;
       color: ${({ theme }) => theme.color.primary};
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    .title {
+      font-size: 2.5rem;
+    }
+    dd,
+    dt {
+      font-size: 2.2rem;
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    .title {
+      font-size: 2.3rem;
+    }
+    dd,
+    dt {
+      font-size: 2rem;
     }
   }
 `;

--- a/src/components/carts/CheckIconButton.tsx
+++ b/src/components/carts/CheckIconButton.tsx
@@ -36,6 +36,20 @@ const CheckIconButtonStyle = styled.button<CheckIconButtonStyleProps>`
       color: inherit;
     }
   }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    svg {
+      width: 3rem;
+      height: 3rem;
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    svg {
+      width: 2.7rem;
+      height: 2.7rem;
+    }
+  }
 `;
 
 export default CheckIconButton;

--- a/src/components/category/Category.tsx
+++ b/src/components/category/Category.tsx
@@ -71,6 +71,27 @@ const CategoryStyle = styled.div`
       }
     }
   }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    .category-list {
+      h2 {
+        font-size: 3rem;
+      }
+      a {
+        font-size: 2.2rem;
+      }
+    }
+  }
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    .category-list {
+      h2 {
+        font-size: 2.3rem;
+      }
+      a {
+        font-size: 1.6rem;
+      }
+    }
+  }
 `;
 
 export default Category;

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -19,8 +19,6 @@ const Button = ({ children, size, scheme, isLoading, ...props }: Props) => {
 
 const ButtonStyle = styled.button<Omit<Props, "children">>`
   white-space: nowrap;
-  font-size: ${({ theme, size }) => theme.buttonSize[size].fontSize};
-  padding: ${({ theme, size }) => theme.buttonSize[size].padding};
   color: ${({ theme, scheme }) => theme.buttonScheme[scheme].color};
   background-color: ${({ theme, scheme }) => theme.buttonScheme[scheme].backgroundColor};
   border-radius: ${({ theme }) => theme.borderRadius.default};
@@ -28,6 +26,21 @@ const ButtonStyle = styled.button<Omit<Props, "children">>`
   opacity: ${({ disabled }) => (disabled ? 0.5 : 1)};
   pointer-events: ${({ disabled }) => (disabled ? "none" : "auto")};
   cursor: ${({ disabled }) => (disabled ? "none" : "pointer")};
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    font-size: ${({ theme, size }) => theme.buttonSize.mobile[size].fontSize};
+    padding: ${({ theme, size }) => theme.buttonSize.mobile[size].padding};
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    font-size: ${({ theme, size }) => theme.buttonSize.tablet[size].fontSize};
+    padding: ${({ theme, size }) => theme.buttonSize.tablet[size].padding};
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.desktop} {
+    font-size: ${({ theme, size }) => theme.buttonSize.desktop[size].fontSize};
+    padding: ${({ theme, size }) => theme.buttonSize.desktop[size].padding};
+  }
 `;
 
 export default Button;

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -37,6 +37,9 @@ const DropdownStyle = styled.div`
   position: relative;
 
   .toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     background: none;
     padding: 0;
     border: none;
@@ -76,6 +79,26 @@ const DropdownStyle = styled.div`
     border: 1px solid ${({ theme }) => theme.color.border};
     border-right: none;
     border-bottom: none;
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    .toggle {
+      font-size: 2rem;
+      width: 3.7rem;
+      height: 3.7rem;
+
+      svg,
+      path,
+      circle {
+        width: 3.7rem;
+        height: 3.7rem;
+        fill: ${({ theme }) => theme.color.authIconColor};
+      }
+    }
+    .panel {
+      top: 5rem;
+      right: 0rem;
+    }
   }
 `;
 

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -33,7 +33,7 @@ const FooterStyle = styled.footer`
 
   .logo {
     font-family: "McLaren", sans-serif;
-    font-size: 1.2rem;
+    font-size: 1.5rem;
     padding-right: 30px;
     color: ${({ theme }) => theme.color.text};
 
@@ -45,8 +45,40 @@ const FooterStyle = styled.footer`
 
   .copyright {
     p {
-      font-size: 0.75rem;
+      font-size: 1rem;
       color: ${({ theme }) => theme.color.text};
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    flex-direction: column;
+    align-items: center;
+    padding: 5rem;
+
+    .logo {
+      font-size: 3rem;
+      padding: 0;
+    }
+    .copyright {
+      p {
+        font-size: 2rem;
+      }
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    flex-direction: column;
+    align-items: center;
+    padding: 5rem;
+
+    .logo {
+      font-size: 2.5rem;
+      padding: 0;
+    }
+    .copyright {
+      p {
+        font-size: 1.8rem;
+      }
     }
   }
 `;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,36 +1,22 @@
 import styled from "styled-components";
 import logoLight from "@/assets/images/logo_light.png";
 import logoDark from "@/assets/images/logo_dark.png";
-import { FaSignInAlt } from "@react-icons/all-files/fa/FaSignInAlt";
-import { FaSignOutAlt } from "@react-icons/all-files/fa/FaSignOutAlt";
-import { FaRegUser } from "@react-icons/all-files/fa/FaRegUser";
-import { FaUserCircle } from "@react-icons/all-files/fa/FaUserCircle";
-import { IoCartOutline } from "@react-icons/all-files/io5/IoCartOutline";
 import { IoList } from "@react-icons/all-files/io5/IoList";
 import ThemeSwitcher from "@/components/header/ThemeSwitcher";
 import { useContext } from "react";
 import { ThemeContext } from "@/context/ThemeContext";
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { useAuthStore } from "@/store/authStore";
-import { logout } from "@/api/auth.api";
-import { useAlert } from "@/hooks/useAlert";
 import Dropdown from "@/components/common/Dropdown";
 import { useCategory } from "@/hooks/useCategory";
 import Category from "@/components/category/Category";
+import AuthHeader from "@/components/header/AuthHeader";
+import UnAuthHeader from "@/components/header/UnAuthHeader";
 
 const Header = () => {
   const { themeName } = useContext(ThemeContext);
-  const navigate = useNavigate();
-  const { isLoggedIn, storeLogout } = useAuthStore();
+  const { isLoggedIn } = useAuthStore();
   const { categories, isCategoriesLoading } = useCategory();
-  const { showAlert } = useAlert();
-
-  const handleLogout = async () => {
-    const { message } = await logout();
-    storeLogout();
-    showAlert(message);
-    navigate("/");
-  };
 
   if (isCategoriesLoading || !categories) {
     return null;
@@ -51,48 +37,8 @@ const Header = () => {
       </div>
 
       <div className="auth-themeswitcher">
-        {isLoggedIn && (
-          <nav className="auth">
-            <Dropdown toggleButtonIcon={<FaUserCircle />}>
-              <ul>
-                <li className="auth-link">
-                  <Link to="/carts">
-                    <IoCartOutline />
-                    &nbsp;장바구니
-                  </Link>
-                </li>
-                <li className="auth-link">
-                  <Link to="/orderlist">
-                    <FaRegUser /> &nbsp;주문내역
-                  </Link>
-                </li>
-                <li className="auth-link">
-                  <button className="logout-btn" onClick={handleLogout}>
-                    <FaSignOutAlt /> &nbsp;로그아웃
-                  </button>
-                </li>
-              </ul>
-            </Dropdown>
-          </nav>
-        )}
-
-        {!isLoggedIn && (
-          <nav className="no-auth">
-            <ul>
-              <li>
-                <Link to="/login">
-                  <FaSignInAlt />
-                  &nbsp;로그인
-                </Link>
-              </li>
-              <li>
-                <Link to="/join">
-                  <FaRegUser /> &nbsp;회원가입
-                </Link>
-              </li>
-            </ul>
-          </nav>
-        )}
+        {isLoggedIn && <AuthHeader />}
+        {!isLoggedIn && <UnAuthHeader />}
         <ThemeSwitcher />
       </div>
     </HeaderStyle>
@@ -158,68 +104,6 @@ const HeaderStyle = styled.header`
     display: flex;
     align-items: center;
     gap: 1rem;
-  }
-
-  .auth {
-    white-space: nowrap;
-    ul {
-      margin: 0;
-    }
-    a {
-      padding: 0.8rem;
-      display: block;
-      &:hover {
-        opacity: 0.8;
-      }
-    }
-
-    .auth-link,
-    .logout-btn {
-      width: 100%;
-      font-size: 1.3rem;
-      font-weight: 600;
-      color: ${({ theme }) => theme.color.text};
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background-color: transparent;
-      height: 100%;
-      cursor: pointer;
-
-      &:hover {
-        opacity: 0.8;
-      }
-
-      .logout-btn {
-        padding: 0.8rem;
-        border-radius: 8px;
-        border: none;
-        background-color: transparent;
-      }
-    }
-  }
-
-  .no-auth {
-    ul {
-      margin: 0;
-      padding: 0;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      gap: 1rem;
-    }
-    li {
-      color: ${({ theme }) => theme.color.text};
-      text-align: center;
-      white-space: nowrap;
-      font-size: 1.3rem;
-      font-weight: 600;
-      color: ${({ theme }) => theme.color.text};
-
-      &:hover {
-        opacity: 0.8;
-      }
-    }
   }
 `;
 

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -48,7 +48,6 @@ const Header = () => {
 const HeaderStyle = styled.header`
   width: 100%;
   margin: 0 auto;
-  /* max-width: ${({ theme }) => theme.layout.width.large}; */
   background-color: ${({ theme }) => theme.color.background};
   padding: 1rem;
 
@@ -61,25 +60,7 @@ const HeaderStyle = styled.header`
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 0.8rem;
-  }
-
-  .dropdown-list-btn {
-    padding: 0.15rem 0.1rem 0.1rem 0.15rem;
-    display: flex;
-    font-size: 2rem;
-    border: 1px solid ${({ theme }) => theme.color.authIconColor};
-    background: none;
-    border-radius: 50%;
-    cursor: pointer;
-
-    svg {
-      fill: ${({ theme }) => theme.color.authIconColor};
-    }
-
-    &:hover {
-      opacity: 0.8;
-    }
+    gap: 1rem;
   }
 
   .logo {
@@ -103,7 +84,38 @@ const HeaderStyle = styled.header`
   .auth-themeswitcher {
     display: flex;
     align-items: center;
+    justify-content: flex-end;
     gap: 1rem;
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    .logo {
+      font-size: 3rem;
+
+      img {
+        max-width: 45px;
+      }
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    .logo {
+      font-size: 2.5rem;
+
+      img {
+        max-width: 60px;
+      }
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.desktop} {
+    .logo {
+      font-size: 3rem;
+
+      img {
+        max-width: 80px;
+      }
+    }
   }
 `;
 

--- a/src/components/common/InputText.tsx
+++ b/src/components/common/InputText.tsx
@@ -24,9 +24,20 @@ const InputTextStyle = styled.input<Props>`
   padding: 0.25rem 0.75rem;
   border: 1px solid ${({ theme, $isError: isError }) => (isError ? "red" : theme.color.border)};
   border-radius: ${({ theme }) => theme.borderRadius.default};
-  font-size: 1rem;
   line-height: 1.5;
   color: ${({ theme }) => theme.color.inputText};
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    font-size: 2.2rem;
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    font-size: 1.8rem;
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.desktop} {
+    font-size: 1.6rem;
+  }
 `;
 
 export default forwardRef(InputText);

--- a/src/components/common/Tabs.tsx
+++ b/src/components/common/Tabs.tsx
@@ -47,7 +47,6 @@ const TabsStyle = styled.div`
       border: none;
       padding: 0.5rem 1.5rem;
       border-radius: 4px 4px 0 0;
-      font-size: 1.5rem;
       background-color: ${({ theme }) => theme.buttonScheme.normal.backgroundColor};
       color: ${({ theme }) => theme.color.primary};
 
@@ -59,6 +58,24 @@ const TabsStyle = styled.div`
   }
   .tab-content {
     padding: 1rem 0.5rem;
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    button {
+      font-size: 2.5rem;
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    button {
+      font-size: 2rem;
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.desktop} {
+    button {
+      font-size: 1.5rem;
+    }
   }
 `;
 

--- a/src/components/common/Title.tsx
+++ b/src/components/common/Title.tsx
@@ -17,8 +17,19 @@ const Title = ({ children, size, color }: Props) => {
 };
 
 const TitleStyle = styled.h1<Omit<Props, "children">>`
-  font-size: ${({ theme, size }) => theme.heading[size].fontSize};
   color: ${({ theme, color }) => (color ? theme.color[color] : theme.color.primary)};
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    font-size: ${({ theme, size }) => theme.heading.mobile[size].fontSize};
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    font-size: ${({ theme, size }) => theme.heading.tablet[size].fontSize};
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.desktop} {
+    font-size: ${({ theme, size }) => theme.heading.desktop[size].fontSize};
+  }
 `;
 
 export default Title;

--- a/src/components/common/banner/Banner.tsx
+++ b/src/components/common/banner/Banner.tsx
@@ -1,0 +1,182 @@
+import { Banner as IBanner } from "@/models/banner.model";
+import styled from "styled-components";
+import BannerItem from "./BannerItem";
+import { useEffect, useMemo, useState } from "react";
+import { FaAngleLeft } from "@react-icons/all-files/fa/FaAngleLeft";
+import { FaAngleRight } from "@react-icons/all-files/fa/FaAngleRight";
+
+interface Props {
+  banners: IBanner[];
+}
+
+const Banner = ({ banners }: Props) => {
+  const [slideBanners, setSlideBanners] = useState<IBanner[]>([]); // 맨 앞 요소에 마지막 banner를 추가, 맨 뒤 요소에 첫번째 banner를 추가한 배열
+  const [currentIdx, setCurrentIdx] = useState<number>(1); // slideBanners 배열에서의 active index를 관리
+  const [indicatorIdx, setIndicatorIdx] = useState<number>(0); // 실제 banners 길이와 동일
+  const [isTransition, setIsTransition] = useState<boolean>(true); // transition 효과 => slideBanners의 맨 첫 번째 또는 맨 마지막 요소일 경우 transition 효과 제거
+
+  const bannerDataSize = banners.length;
+  const sliderSize = bannerDataSize + 2;
+
+  const handlePrev = () => {
+    setCurrentIdx((prev) => (prev + (sliderSize - 1)) % sliderSize);
+    setIndicatorIdx((prev) => (prev + (bannerDataSize - 1)) % bannerDataSize);
+    setIsTransition(true);
+  };
+
+  const handleNext = () => {
+    setCurrentIdx((prev) => (prev + 1) % sliderSize);
+    setIndicatorIdx((prev) => (prev + 1) % bannerDataSize);
+    setIsTransition(true);
+  };
+
+  const handleClickIndicator = (i: number) => {
+    setIndicatorIdx(i);
+    setCurrentIdx(i + 1);
+    setIsTransition(true);
+  };
+
+  const transformValue = useMemo(() => {
+    return currentIdx * -100;
+  }, [currentIdx]);
+
+  useEffect(() => {
+    if (banners.length === 0) return;
+
+    const slideBanners = [banners[banners.length - 1], ...banners, banners[0]];
+    setSlideBanners(slideBanners);
+    console.log(slideBanners);
+  }, [banners]);
+
+  useEffect(() => {
+    let timer: NodeJS.Timer;
+
+    if (currentIdx === sliderSize - 1) {
+      timer = setTimeout(() => {
+        setCurrentIdx(1);
+        setIsTransition(false);
+      }, 500);
+    } else if (currentIdx === 0) {
+      timer = setTimeout(() => {
+        setCurrentIdx(bannerDataSize);
+        setIsTransition(false);
+      }, 500);
+    }
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [currentIdx, bannerDataSize, sliderSize]);
+
+  useEffect(() => {
+    // 3초마다 자동으로 슬라이드 넘어가도록 구현
+    const intervalId = setInterval(() => {
+      setCurrentIdx((prev) => (prev + 1) % sliderSize);
+      setIndicatorIdx((prev) => (prev + 1) % bannerDataSize);
+      setIsTransition(true);
+    }, 3000);
+
+    return () => clearInterval(intervalId);
+  }, [sliderSize, bannerDataSize]);
+
+  return (
+    <BannerStyle>
+      <BannerContainerStyle $isTransition={isTransition} $transformValue={transformValue}>
+        {slideBanners.map((banner, i) => (
+          <BannerItem key={i} banner={banner} />
+        ))}
+      </BannerContainerStyle>
+      <BannerSlideBtnStyle>
+        <button className="prev" onClick={handlePrev}>
+          <FaAngleLeft />
+        </button>
+        <button className="next" onClick={handleNext}>
+          <FaAngleRight />
+        </button>
+      </BannerSlideBtnStyle>
+      <BannerIndicatorStyle>
+        {banners.map((banner, i) => (
+          <span
+            key={i}
+            className={indicatorIdx === banner.id ? "active" : ""}
+            onClick={() => {
+              handleClickIndicator(i);
+            }}
+          ></span>
+        ))}
+      </BannerIndicatorStyle>
+    </BannerStyle>
+  );
+};
+
+interface BannerContainerStyleProps {
+  $transformValue: number;
+  $isTransition: boolean;
+}
+const BannerStyle = styled.div`
+  overflow: hidden;
+  position: relative;
+`;
+
+const BannerContainerStyle = styled.div<BannerContainerStyleProps>`
+  display: flex;
+  transform: translateX(${({ $transformValue }) => $transformValue}%);
+  transition: ${({ $isTransition }) => ($isTransition ? "transform 0.5s ease-in-out" : "none")};
+`;
+
+const BannerSlideBtnStyle = styled.div`
+  button {
+    cursor: pointer;
+    border: none;
+    padding: 0;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    font-size: 2rem;
+    background-color: ${({ theme }) => theme.color.arrowBackgroundColor};
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+
+    svg {
+      fill: #fff;
+    }
+
+    &.prev {
+      left: 0.6rem;
+    }
+
+    &.next {
+      right: 0.6rem;
+    }
+
+    &:hover {
+      opacity: 0.8;
+    }
+  }
+`;
+
+const BannerIndicatorStyle = styled.div`
+  position: absolute;
+  bottom: 0.8rem;
+  left: 50%;
+  transform: translateX(-50%);
+  span {
+    display: inline-block;
+    width: 0.8rem;
+    height: 0.8rem;
+    border-radius: 50%;
+    background-color: ${({ theme }) => theme.color.arrowBackgroundColor};
+    margin: 0 4px;
+    cursor: pointer;
+
+    &.active {
+      background-color: #fff;
+    }
+  }
+`;
+
+export default Banner;

--- a/src/components/common/banner/Banner.tsx
+++ b/src/components/common/banner/Banner.tsx
@@ -45,7 +45,6 @@ const Banner = ({ banners }: Props) => {
 
     const slideBanners = [banners[banners.length - 1], ...banners, banners[0]];
     setSlideBanners(slideBanners);
-    console.log(slideBanners);
   }, [banners]);
 
   useEffect(() => {

--- a/src/components/common/banner/Banner.tsx
+++ b/src/components/common/banner/Banner.tsx
@@ -73,7 +73,7 @@ const Banner = ({ banners }: Props) => {
       setCurrentIdx((prev) => (prev + 1) % sliderSize);
       setIndicatorIdx((prev) => (prev + 1) % bannerDataSize);
       setIsTransition(true);
-    }, 3000);
+    }, 5000);
 
     return () => clearInterval(intervalId);
   }, [sliderSize, bannerDataSize]);
@@ -112,6 +112,7 @@ interface BannerContainerStyleProps {
   $transformValue: number;
   $isTransition: boolean;
 }
+
 const BannerStyle = styled.div`
   overflow: hidden;
   position: relative;

--- a/src/components/common/banner/BannerItem.tsx
+++ b/src/components/common/banner/BannerItem.tsx
@@ -1,0 +1,66 @@
+import { Banner } from "@/models/banner.model";
+import styled from "styled-components";
+
+interface Props {
+  banner: Banner;
+}
+const BannerItem = ({ banner }: Props) => {
+  return (
+    <BannerItemStyle>
+      <div className="img">
+        <img src={banner.image} alt={banner.title} />
+      </div>
+      <div className="content">
+        <h2>{banner.title}</h2>
+        <p>{banner.description}</p>
+      </div>
+    </BannerItemStyle>
+  );
+};
+
+const BannerItemStyle = styled.div`
+  flex: 0 0 100%;
+  /* display: flex;
+  align-items: center;
+  justify-content: center; */
+  text-align: center;
+
+  position: relative;
+
+  .img {
+    img {
+      width: 100%;
+      max-width: 100%;
+    }
+  }
+
+  .content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+
+    position: absolute;
+    top: 0;
+    left: 0;
+    padding-left: 4rem;
+    width: 40%;
+    height: 100%;
+    background: linear-gradient(to right, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
+
+    h2 {
+      color: #111;
+      font-size: 2rem;
+      font-weight: 700;
+      margin-bottom: 1rem;
+    }
+
+    p {
+      color: #2b2b2b;
+      font-size: 1.2rem;
+      margin: 0;
+    }
+  }
+`;
+
+export default BannerItem;

--- a/src/components/common/banner/BannerItem.tsx
+++ b/src/components/common/banner/BannerItem.tsx
@@ -20,9 +20,6 @@ const BannerItem = ({ banner }: Props) => {
 
 const BannerItemStyle = styled.div`
   flex: 0 0 100%;
-  /* display: flex;
-  align-items: center;
-  justify-content: center; */
   text-align: center;
 
   position: relative;
@@ -57,8 +54,30 @@ const BannerItemStyle = styled.div`
 
     p {
       color: #2b2b2b;
-      font-size: 1.2rem;
+      font-size: 1.4rem;
       margin: 0;
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    .content {
+      h2 {
+        font-size: 2.8rem;
+      }
+      p {
+        font-size: 2rem;
+      }
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    .content {
+      h2 {
+        font-size: 2.5rem;
+      }
+      p {
+        font-size: 1.7rem;
+      }
     }
   }
 `;

--- a/src/components/header/AuthHeader.tsx
+++ b/src/components/header/AuthHeader.tsx
@@ -1,0 +1,138 @@
+import styled from "styled-components";
+import Dropdown from "@/components/common/Dropdown";
+import { Link, useNavigate } from "react-router-dom";
+import { FaUserCircle } from "@react-icons/all-files/fa/FaUserCircle";
+import { FaRegUser } from "@react-icons/all-files/fa/FaRegUser";
+import { FaSignOutAlt } from "@react-icons/all-files/fa/FaSignOutAlt";
+import { useAuthStore } from "@/store/authStore";
+import { logout } from "@/api/auth.api";
+import { IoCartOutline } from "@react-icons/all-files/io5/IoCartOutline";
+import { useAlert } from "@/hooks/useAlert";
+import { useCartStore } from "@/store/cartStore";
+import { useCarts } from "@/hooks/useCarts";
+import { useEffect } from "react";
+
+const AuthHeader = () => {
+  const navigate = useNavigate();
+  const { storeLogout } = useAuthStore();
+  const { showAlert } = useAlert();
+  const { carts } = useCarts();
+  const { cartItemsCount, updateCartItemsCount } = useCartStore();
+
+  const handleLogout = async () => {
+    const { message } = await logout();
+    storeLogout();
+    showAlert(message);
+    navigate("/");
+  };
+
+  useEffect(() => {
+    if (carts) {
+      updateCartItemsCount(carts.length);
+    }
+  }, [carts]);
+
+  return (
+    <AuthHeaderStyle>
+      <div className="auth-cart">
+        <Link to="/carts">
+          <IoCartOutline />
+          <span className="cart-icon-count">{cartItemsCount}</span>
+        </Link>
+      </div>
+      <Dropdown toggleButtonIcon={<FaUserCircle />}>
+        <ul>
+          <li className="auth-link">
+            <Link to="/orderlist">
+              <FaRegUser /> &nbsp;주문내역
+            </Link>
+          </li>
+          <li className="auth-link">
+            <button className="logout-btn" onClick={handleLogout}>
+              <FaSignOutAlt /> &nbsp;로그아웃
+            </button>
+          </li>
+        </ul>
+      </Dropdown>
+    </AuthHeaderStyle>
+  );
+};
+
+const AuthHeaderStyle = styled.nav`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+  gap: 1rem;
+
+  .auth-cart {
+    position: relative;
+    padding: 0;
+    cursor: pointer;
+
+    &:hover {
+      opacity: 0.8;
+    }
+
+    a {
+      padding: 0;
+    }
+    svg {
+      width: 2.4rem;
+      height: 2.4rem;
+    }
+
+    .cart-icon-count {
+      position: absolute;
+      text-align: center;
+      top: -7px;
+      right: -3px;
+      border-radius: 50%;
+      width: 1.6rem;
+      height: 1.6rem;
+      font-size: 1.3rem;
+      color: #fff;
+      background-color: ${({ theme }) => theme.color.third};
+    }
+  }
+
+  .auth-link,
+  .logout-btn {
+    width: 100%;
+    font-size: 1.3rem;
+    font-weight: 600;
+    color: ${({ theme }) => theme.color.text};
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: transparent;
+    height: 100%;
+    cursor: pointer;
+
+    &:hover {
+      opacity: 0.8;
+    }
+
+    ul {
+      margin: 0;
+    }
+
+    a {
+      padding: 0.8rem;
+      display: block;
+
+      &:hover {
+        opacity: 0.8;
+      }
+    }
+
+    .logout-btn {
+      padding: 0.8rem;
+      border-radius: 8px;
+      border: none;
+      background-color: transparent;
+    }
+  }
+`;
+
+export default AuthHeader;

--- a/src/components/header/AuthHeader.tsx
+++ b/src/components/header/AuthHeader.tsx
@@ -78,14 +78,14 @@ const AuthHeaderStyle = styled.nav`
       padding: 0;
     }
     svg {
-      width: 2.4rem;
-      height: 2.4rem;
+      width: 2.5rem;
+      height: 2.5rem;
     }
 
     .cart-icon-count {
       position: absolute;
       text-align: center;
-      top: -7px;
+      top: -5px;
       right: -3px;
       border-radius: 50%;
       width: 1.6rem;
@@ -131,6 +131,60 @@ const AuthHeaderStyle = styled.nav`
       border-radius: 8px;
       border: none;
       background-color: transparent;
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    .auth-cart {
+      font-size: 2rem;
+      width: 3.7rem;
+      height: 3.7rem;
+
+      svg,
+      path,
+      circle {
+        width: 3.7rem;
+        height: 3.7rem;
+      }
+
+      .cart-icon-count {
+        width: 2.3rem;
+        height: 2.3rem;
+        font-size: 1.8rem;
+      }
+    }
+    a {
+      font-size: 2.2rem;
+    }
+    .logout-btn {
+      font-size: 2.2rem;
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    .auth-cart {
+      font-size: 2rem;
+      width: 3rem;
+      height: 3rem;
+
+      svg,
+      path,
+      circle {
+        width: 3rem;
+        height: 3rem;
+      }
+
+      .cart-icon-count {
+        width: 2rem;
+        height: 2rem;
+        font-size: 1.6rem;
+      }
+    }
+    a {
+      font-size: 1.6rem;
+    }
+    .logout-btn {
+      font-size: 1.6rem;
     }
   }
 `;

--- a/src/components/header/ThemeSwitcher.tsx
+++ b/src/components/header/ThemeSwitcher.tsx
@@ -3,13 +3,15 @@ import { ThemeContext } from "@/context/ThemeContext";
 import styled from "styled-components";
 import { IoMdMoon } from "@react-icons/all-files/io/IoMdMoon";
 import { IoSunny } from "@react-icons/all-files/io5/IoSunny";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 const ThemeSwitcher = () => {
   const { themeName, toggleTheme } = useContext(ThemeContext);
+  const { isMobile } = useMediaQuery();
 
   return (
     <IconButton onClick={toggleTheme}>
       {themeName === "light" ? <IoSunny /> : <IoMdMoon />}
-      <span>&nbsp;{themeName}</span>
+      {!isMobile && <span>&nbsp;{themeName}</span>}
     </IconButton>
   );
 };
@@ -17,11 +19,10 @@ const ThemeSwitcher = () => {
 const IconButton = styled.button`
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-end;
   padding: 0;
   border: none;
   cursor: pointer;
-  width: 5rem;
   background-color: transparent; /* 배경색을 투명으로 설정 */
 
   svg {
@@ -37,6 +38,25 @@ const IconButton = styled.button`
 
   &:hover {
     opacity: 0.8;
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    svg,
+    path,
+    circle {
+      width: 3.7rem;
+      height: 3.7rem;
+    }
+
+    span {
+      font-size: 2rem;
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    span {
+      font-size: 1.8rem;
+    }
   }
 `;
 

--- a/src/components/header/ThemeSwitcher.tsx
+++ b/src/components/header/ThemeSwitcher.tsx
@@ -25,13 +25,13 @@ const IconButton = styled.button`
   background-color: transparent; /* 배경색을 투명으로 설정 */
 
   svg {
-    width: 2rem;
-    height: 2rem;
+    width: 2.4rem;
+    height: 2.4rem;
     fill: ${({ theme }) => theme.color.themeIconColor};
   }
 
   span {
-    font-size: 1.1rem;
+    font-size: 1.3rem;
     color: ${({ theme }) => theme.color.themeIconColor};
   }
 

--- a/src/components/header/UnAuthHeader.tsx
+++ b/src/components/header/UnAuthHeader.tsx
@@ -1,0 +1,53 @@
+import { FaRegUser } from "@react-icons/all-files/fa/FaRegUser";
+import { FaSignInAlt } from "@react-icons/all-files/fa/FaSignInAlt";
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+
+const UnAuthHeader = () => {
+  return (
+    <UnAuthHeaderStyle>
+      <nav className="no-auth">
+        <ul>
+          <li>
+            <Link to="/login">
+              <FaSignInAlt />
+              &nbsp;로그인
+            </Link>
+          </li>
+          <li>
+            <Link to="/join">
+              <FaRegUser /> &nbsp;회원가입
+            </Link>
+          </li>
+        </ul>
+      </nav>
+    </UnAuthHeaderStyle>
+  );
+};
+
+const UnAuthHeaderStyle = styled.div`
+  .no-auth {
+    ul {
+      margin: 0;
+      padding: 0;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: 1rem;
+    }
+    li {
+      color: ${({ theme }) => theme.color.text};
+      text-align: center;
+      white-space: nowrap;
+      font-size: 1.3rem;
+      font-weight: 600;
+      color: ${({ theme }) => theme.color.text};
+
+      &:hover {
+        opacity: 0.8;
+      }
+    }
+  }
+`;
+
+export default UnAuthHeader;

--- a/src/components/header/UnAuthHeader.tsx
+++ b/src/components/header/UnAuthHeader.tsx
@@ -11,12 +11,13 @@ const UnAuthHeader = () => {
           <li>
             <Link to="/login">
               <FaSignInAlt />
-              &nbsp;로그인
+              로그인
             </Link>
           </li>
           <li>
             <Link to="/join">
-              <FaRegUser /> &nbsp;회원가입
+              <FaRegUser />
+              회원가입
             </Link>
           </li>
         </ul>
@@ -39,12 +40,28 @@ const UnAuthHeaderStyle = styled.div`
       color: ${({ theme }) => theme.color.text};
       text-align: center;
       white-space: nowrap;
-      font-size: 1.3rem;
+      font-size: 1.4rem;
       font-weight: 600;
       color: ${({ theme }) => theme.color.text};
 
       &:hover {
         opacity: 0.8;
+      }
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    .no-auth {
+      li {
+        font-size: 2rem;
+      }
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    .no-auth {
+      li {
+        font-size: 1.6rem;
       }
     }
   }

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -23,9 +23,20 @@ const WrapperStyle = styled.div`
 
 const LayoutStyle = styled.main`
   width: 100%;
-  max-width: 70%;
   flex: 1;
   margin: 0 auto;
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    padding: 1.8rem 1.5rem;
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    padding: 1.8rem 1.5rem;
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.desktop} {
+    max-width: 80vw;
+  }
 `;
 
 export default Layout;

--- a/src/components/main/MainBest.tsx
+++ b/src/components/main/MainBest.tsx
@@ -19,6 +19,18 @@ const MainBestStyle = styled.div`
   display: grid;
   grid-template-columns: repeat(5, 1fr);
   gap: 1.5rem;
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.desktop} {
+    grid-template-columns: repeat(5, 1fr);
+  }
 `;
 
 export default MainBest;

--- a/src/components/main/MainBest.tsx
+++ b/src/components/main/MainBest.tsx
@@ -1,0 +1,24 @@
+import { Book } from "@/models/book.model";
+import styled from "styled-components";
+import BestBookItem from "../books/BestBookItem";
+
+interface Props {
+  books: Book[];
+}
+const MainBest = ({ books }: Props) => {
+  return (
+    <MainBestStyle>
+      {books.map((book, i) => (
+        <BestBookItem key={book.id} book={book} itemIdx={i} />
+      ))}
+    </MainBestStyle>
+  );
+};
+
+const MainBestStyle = styled.div`
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 1.5rem;
+`;
+
+export default MainBest;

--- a/src/components/main/MainNewBooks.tsx
+++ b/src/components/main/MainNewBooks.tsx
@@ -19,6 +19,10 @@ const MainNewBooksStyle = styled.div`
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 1rem;
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    grid-template-columns: repeat(2, 1fr);
+  }
 `;
 
 export default MainNewBooks;

--- a/src/components/main/MainNewBooks.tsx
+++ b/src/components/main/MainNewBooks.tsx
@@ -1,0 +1,24 @@
+import { Book } from "@/models/book.model";
+import styled from "styled-components";
+import BookItem from "../books/BookItem";
+
+interface Props {
+  books: Book[];
+}
+const MainNewBooks = ({ books }: Props) => {
+  return (
+    <MainNewBooksStyle>
+      {books.map((book) => (
+        <BookItem key={book.id} book={book} view="grid" />
+      ))}
+    </MainNewBooksStyle>
+  );
+};
+
+const MainNewBooksStyle = styled.div`
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+`;
+
+export default MainNewBooks;

--- a/src/components/main/MainReview.tsx
+++ b/src/components/main/MainReview.tsx
@@ -1,0 +1,50 @@
+import styled from "styled-components";
+import BookReviewItem from "@/components/book/BookReviewItem";
+import { BookReviewItem as IBookReviewItem } from "@/models/book.model";
+import Slider from "react-slick";
+
+import "slick-carousel/slick/slick.css";
+import "slick-carousel/slick/slick-theme.css";
+
+interface Props {
+  reviews: IBookReviewItem[];
+}
+
+const MainReview = ({ reviews }: Props) => {
+  const sliderSettings = {
+    dots: true,
+    infinite: true,
+    speed: 500,
+    slidesToShow: 3,
+    slidesToScroll: 3,
+    gap: 16,
+  };
+  return (
+    <MainReviewStyle>
+      <Slider {...sliderSettings}>
+        {reviews.map((review) => (
+          <BookReviewItem key={review.id} review={review} />
+        ))}
+      </Slider>
+    </MainReviewStyle>
+  );
+};
+
+const MainReviewStyle = styled.div`
+  padding: 0 0 1.5rem 0;
+
+  .slick-track {
+    padding: 0.8rem 0;
+  }
+
+  .slick-slide > div {
+    margin: 0 0.8rem;
+  }
+
+  .slick-prev:before,
+  .slick-next:before {
+    color: ${({ theme }) => theme.color.text};
+  }
+`;
+
+export default MainReview;

--- a/src/components/main/MainReview.tsx
+++ b/src/components/main/MainReview.tsx
@@ -5,18 +5,21 @@ import Slider from "react-slick";
 
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 
 interface Props {
   reviews: IBookReviewItem[];
 }
 
 const MainReview = ({ reviews }: Props) => {
+  const { isMobile } = useMediaQuery();
+
   const sliderSettings = {
     dots: true,
     infinite: true,
     speed: 500,
-    slidesToShow: 3,
-    slidesToScroll: 3,
+    slidesToShow: isMobile ? 1 : 3,
+    slidesToScroll: isMobile ? 1 : 3,
     gap: 16,
   };
   return (
@@ -44,6 +47,18 @@ const MainReviewStyle = styled.div`
   .slick-prev:before,
   .slick-next:before {
     color: ${({ theme }) => theme.color.text};
+  }
+  .slick-prev {
+    left: 0;
+  }
+  .slick-next {
+    right: 0;
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    .slick-slide > div {
+      margin: 0 3rem;
+    }
   }
 `;
 

--- a/src/components/order/OrderDetailSummary.tsx
+++ b/src/components/order/OrderDetailSummary.tsx
@@ -1,0 +1,109 @@
+import { Cart } from "@/models/cart.model";
+import { formatNumber } from "@/utils/format";
+import { getImgSrc } from "@/utils/image";
+import styled from "styled-components";
+
+interface Props {
+  orderItems: Cart[];
+}
+const OrderDetailSummary = ({ orderItems }: Props) => {
+  console.log(orderItems);
+  return (
+    <OrderDetailSummaryStyle>
+      {orderItems.map((item) => {
+        return (
+          <div key={item.bookId} className="order-data">
+            <ImgBackground url={getImgSrc(Number(item.imgUrl))}></ImgBackground>
+
+            <div className="order-contents">
+              <p>{item.title}</p>
+              <p className="sub-contents">
+                <span>{formatNumber(item.price)}원</span>
+                <span>{item.quantity}권</span>
+              </p>
+              <p className="total-price">총 금액 {formatNumber(item.price * item.quantity)}원</p>
+            </div>
+          </div>
+        );
+      })}
+    </OrderDetailSummaryStyle>
+  );
+};
+
+interface ImgBackgroundProps {
+  url: string;
+}
+
+const ImgBackground = styled.div<ImgBackgroundProps>`
+  flex: 1 1 25%;
+  border-radius: ${({ theme }) => theme.borderRadius.default};
+  background-position: center;
+  background-image: url(${({ url }) => url});
+  background-size: cover;
+  background-repeat: no-repeat;
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    flex: 1 1 50%;
+  }
+`;
+
+const OrderDetailSummaryStyle = styled.div`
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 1rem;
+
+  .order-data {
+    width: 49%;
+    padding: 0.8rem;
+    border: 1px solid ${({ theme }) => theme.color.border};
+    border-radius: ${({ theme }) => theme.borderRadius.default};
+    display: flex;
+    justify-content: space-between;
+
+    gap: 1rem;
+  }
+
+  .order-contents {
+    flex: 1 1 100%;
+    p {
+      margin: 0;
+      font-size: 1.5rem;
+    }
+    .total-price {
+      color: ${({ theme }) => theme.color.primary};
+      font-weight: 600;
+    }
+  }
+
+  .sub-contents {
+    display: flex;
+    gap: 1rem;
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    .order-data {
+      gap: 1.5rem;
+      width: 100%;
+    }
+    .order-contents {
+      flex: 1 1 100%;
+      p {
+        font-size: 2rem;
+      }
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    .order-contents {
+      flex: 1 1 100%;
+      p {
+        font-size: 1.7rem;
+      }
+    }
+  }
+`;
+
+export default OrderDetailSummary;

--- a/src/components/order/OrderItemDetail.tsx
+++ b/src/components/order/OrderItemDetail.tsx
@@ -57,20 +57,12 @@ const OrderItemDetailStyle = styled.div`
   .book-img {
     border-radius: ${({ theme }) => theme.borderRadius.default};
     overflow: hidden;
-    /* flex: 1; */
     max-width: 100px;
 
     img {
       width: 100%;
-      /* max-width: 80px; */
-      /* height: auto; */
+      height: 100%;
       object-fit: cover;
-    }
-
-    @media screen and (max-width: 500px) {
-      img {
-        max-width: 60px;
-      }
     }
   }
 
@@ -95,8 +87,42 @@ const OrderItemDetailStyle = styled.div`
     }
 
     dd {
-      font-size: 1.1rem;
+      font-size: 1.3rem;
       margin: 0;
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    .book-img {
+      img {
+        max-width: 50px;
+      }
+    }
+    .contents {
+      dt {
+        font-size: 1.8rem;
+      }
+
+      dd {
+        font-size: 1.8rem;
+      }
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    .book-img {
+      img {
+        max-width: 60px;
+      }
+    }
+    .contents {
+      dt {
+        font-size: 1.6rem;
+      }
+
+      dd {
+        font-size: 1.6rem;
+      }
     }
   }
 `;

--- a/src/hooks/useBookDetail.ts
+++ b/src/hooks/useBookDetail.ts
@@ -8,9 +8,12 @@ import { addBookReview, fetchBookReview } from "@/api/review.api";
 import { useAlert } from "@/hooks/useAlert";
 import { BookReviewItem } from "@/models/book.model";
 import { useToast } from "@/hooks/useToast";
+import { useCartStore } from "@/store/cartStore";
 
 export const useBookDetail = (bookId: string | undefined) => {
   const [isAddToCart, setIsAddToCart] = useState<boolean>(false);
+  const [resMessage, setResMessage] = useState<string>("");
+  const { updateCartItemsCount } = useCartStore();
   const { showAlert } = useAlert();
   const { showToast } = useToast();
   const queryClient = useQueryClient();
@@ -26,8 +29,13 @@ export const useBookDetail = (bookId: string | undefined) => {
   });
 
   const { mutate: addToCart } = useMutation({
-    mutationFn: ({ bookId, quantity }: addToCartParams) => requestAddToCart({ bookId, quantity }),
-    onSuccess: () => {
+    mutationFn: async ({ bookId, quantity }: addToCartParams) => {
+      const { cartItemsCount, message } = await requestAddToCart({ bookId, quantity });
+      return { cartItemsCount, message };
+    },
+    onSuccess: ({ cartItemsCount, message }) => {
+      updateCartItemsCount(cartItemsCount);
+      setResMessage(message);
       setIsAddToCart(true);
       setTimeout(() => {
         setIsAddToCart(false);
@@ -82,5 +90,6 @@ export const useBookDetail = (bookId: string | undefined) => {
     bookReview,
     isBookReviewLoading,
     addReview,
+    message: resMessage,
   };
 };

--- a/src/hooks/useBooksInfinity.ts
+++ b/src/hooks/useBooksInfinity.ts
@@ -45,7 +45,7 @@ export const useBooksInfinity = () => {
     isEmpty,
     message,
     isBooksFetching: isFetching,
-    isBookLoading: isLoading,
+    isBooksLoading: isLoading,
     fetchNextPage,
     hasNextPage,
   };

--- a/src/hooks/useCarts.ts
+++ b/src/hooks/useCarts.ts
@@ -1,8 +1,10 @@
 import { fetchAllCart, requestDeletedCartItem } from "@/api/carts.api";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { queryKey } from "@/constants/queryKey";
+import { useCartStore } from "@/store/cartStore";
 
 export const useCarts = () => {
+  const { updateCartItemsCount } = useCartStore();
   const { data: carts, isLoading: isCartsLoading } = useQuery({
     queryKey: [queryKey.carts],
     queryFn: fetchAllCart,
@@ -12,7 +14,10 @@ export const useCarts = () => {
 
   const { mutate: deletedCartItem } = useMutation({
     mutationFn: (cartId: number) => requestDeletedCartItem(cartId),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: [queryKey.carts] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [queryKey.carts] });
+      if (carts) updateCartItemsCount(carts.items.length);
+    },
   });
 
   return {

--- a/src/hooks/useMain.ts
+++ b/src/hooks/useMain.ts
@@ -1,0 +1,33 @@
+import { fetchBanners } from "@/api/banner.api";
+import { fetchBestBooks, fetchBooks } from "@/api/books.api";
+import { fetchReviewsAll } from "@/api/review.api";
+import { Banner } from "@/models/banner.model";
+import { Book, BookReviewItem } from "@/models/book.model";
+import { useEffect, useState } from "react";
+
+export const useMain = () => {
+  const [reviews, setReviews] = useState<BookReviewItem[]>([]);
+  const [newBooks, setNewBooks] = useState<Book[]>([]);
+  const [bestBooks, setBestBooks] = useState<Book[]>([]);
+  const [banners, setBanners] = useState<Banner[]>([]);
+
+  useEffect(() => {
+    fetchReviewsAll().then((reviews) => {
+      setReviews(reviews);
+    });
+
+    fetchBooks({ new: true, page: 1, limit: 4 }).then(({ books }) => {
+      setNewBooks(books);
+    });
+
+    fetchBestBooks().then((books) => {
+      setBestBooks(books);
+    });
+
+    fetchBanners().then((banners) => {
+      setBanners(banners);
+    });
+  }, []);
+
+  return { reviews, newBooks, bestBooks, banners };
+};

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+import { getTheme } from "@/style/theme";
+
+const MOBILE_MEDIA_QUERY = getTheme("light").mediaQuery.mobile;
+
+export const useMediaQuery = () => {
+  const [isMobile, setIsMobile] = useState(window.matchMedia(MOBILE_MEDIA_QUERY).matches);
+
+  useEffect(() => {
+    const mediaQueryList = window.matchMedia(MOBILE_MEDIA_QUERY);
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setIsMobile(event.matches);
+    };
+
+    mediaQueryList.addEventListener("change", handleChange);
+
+    return () => {
+      mediaQueryList.removeEventListener("change", handleChange);
+    };
+  }, []);
+
+  return { isMobile };
+};

--- a/src/mock/banner.ts
+++ b/src/mock/banner.ts
@@ -1,0 +1,18 @@
+import { HttpResponse, http } from "msw";
+import { fakerKO as faker } from "@faker-js/faker";
+import { Banner } from "@/models/banner.model";
+
+// faker api 사용
+const mockBannerData: Banner[] = Array.from({ length: 6 }, (_, i) => ({
+  id: i,
+  title: faker.lorem.sentence().slice(0, 10),
+  description: faker.lorem.paragraph().slice(0, 40),
+  image: `https://picsum.photos/id/${faker.helpers.rangeToNumber({ min: 0, max: 80 })}/1200/400`,
+  clickUrl: "http://some.url",
+  target: "_blank", // 새창에서 열기
+}));
+
+// 핸들러 작성
+export const banners = http.get(`${process.env.REACT_APP_BASE_URL}/banners`, () => {
+  return HttpResponse.json(mockBannerData, { status: 200 });
+});

--- a/src/mock/books.ts
+++ b/src/mock/books.ts
@@ -5,7 +5,7 @@ import { fakerKO as faker } from "@faker-js/faker";
 // faker api 사용
 const mockBestBooksData: Book[] = Array.from({ length: 10 }, (_, i) => ({
   id: i,
-  title: faker.lorem.sentence(),
+  title: faker.lorem.sentence().slice(0, 10),
   imgUrl: faker.helpers.rangeToNumber({ min: 0, max: 50 }),
   categoryId: faker.helpers.rangeToNumber({ min: 1, max: 5 }),
   form: "종이책",

--- a/src/mock/books.ts
+++ b/src/mock/books.ts
@@ -1,0 +1,26 @@
+import { Book } from "@/models/book.model";
+import { HttpResponse, http } from "msw";
+import { fakerKO as faker } from "@faker-js/faker";
+
+// faker api 사용
+const mockBestBooksData: Book[] = Array.from({ length: 10 }, (_, i) => ({
+  id: i,
+  title: faker.lorem.sentence(),
+  imgUrl: faker.helpers.rangeToNumber({ min: 0, max: 50 }),
+  categoryId: faker.helpers.rangeToNumber({ min: 1, max: 5 }),
+  form: "종이책",
+  isbn: faker.commerce.isbn(),
+  summary: faker.lorem.paragraph(),
+  detail: faker.lorem.paragraph(),
+  author: faker.person.firstName(),
+  pages: faker.helpers.rangeToNumber({ min: 50, max: 900 }),
+  contents: faker.lorem.paragraph(),
+  price: faker.helpers.rangeToNumber({ min: 1000, max: 50000 }),
+  likes: faker.helpers.rangeToNumber({ min: 0, max: 999 }),
+  publishedDate: faker.date.past().toString(),
+}));
+
+// 핸들러 작성
+export const bestBooks = http.get(`${process.env.REACT_APP_BASE_URL}/books/best`, () => {
+  return HttpResponse.json(mockBestBooksData, { status: 200 });
+});

--- a/src/mock/browser.ts
+++ b/src/mock/browser.ts
@@ -1,7 +1,9 @@
 import { setupWorker } from "msw/browser";
-import { addReview, reviewsById } from "./review";
+import { addReview, reviewsById, reviewForMain } from "./review";
+import { bestBooks } from "./books";
+import { banners } from "./banner";
 
-const handlers = [reviewsById, addReview];
+const handlers = [reviewsById, addReview, reviewForMain, bestBooks, banners];
 
 // 서비스 워커 생성
 export const worker = setupWorker(...handlers);

--- a/src/mock/review.ts
+++ b/src/mock/review.ts
@@ -3,7 +3,7 @@ import { HttpResponse, http } from "msw";
 import { fakerKO as faker } from "@faker-js/faker";
 
 // faker api 사용
-const mockReviewData: BookReviewItem[] = Array.from({ length: 8 }, (_, i) => ({
+const mockReviewData: BookReviewItem[] = Array.from({ length: 10 }, (_, i) => ({
   id: i,
   userName: `${faker.person.lastName()}${faker.person.firstName()}`,
   review: faker.lorem.paragraph(),
@@ -23,3 +23,7 @@ export const addReview = http.post(
     return HttpResponse.json({ message: "리뷰가 등록되었습니다.", reviewData }, { status: 200 });
   },
 );
+
+export const reviewForMain = http.get(`${process.env.REACT_APP_BASE_URL}/reviews`, () => {
+  return HttpResponse.json(mockReviewData, { status: 200 });
+});

--- a/src/models/banner.model.ts
+++ b/src/models/banner.model.ts
@@ -1,0 +1,8 @@
+export interface Banner {
+  id: number;
+  title: string;
+  description: string;
+  image: string; // 이미지 url
+  clickUrl: string; // 배너 이미지 클릭 시 이동할 url
+  target: string; // a요소의 target 속성
+}

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -139,21 +139,18 @@ const ModalBookImg = styled.div`
 
 const BookDetailPageStyle = styled.section`
   width: 100%;
-  margin: 0 auto;
-  max-width: ${({ theme }) => theme.layout.width.large};
   padding: 2rem;
   position: relative;
 
   header {
     display: flex;
-    flex-wrap: wrap;
     gap: 3rem;
-    padding: 0 0 24px 0;
+    padding: 0 0 1.8rem 0;
   }
 
   .img {
     flex: 1;
-    min-width: 40%;
+    min-width: 45%;
 
     img {
       cursor: pointer;
@@ -184,12 +181,7 @@ const BookDetailPageStyle = styled.section`
     }
 
     dt {
-      font-size: 1.6rem;
       color: ${({ theme }) => theme.color.secondary};
-    }
-
-    dd {
-      font-size: 1.3rem;
     }
 
     a {
@@ -206,7 +198,6 @@ const BookDetailPageStyle = styled.section`
   }
 
   p {
-    font-size: 1.3rem;
     margin: 1.2rem 0;
   }
 
@@ -214,6 +205,52 @@ const BookDetailPageStyle = styled.section`
     display: flex;
     flex-direction: column;
     gap: 1.7rem;
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    header {
+      flex-wrap: wrap;
+    }
+
+    dt {
+      font-size: 2.4rem;
+    }
+
+    dd {
+      font-size: 2.2rem;
+    }
+
+    p {
+      font-size: 2.2rem;
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    dt {
+      font-size: 2.2rem;
+    }
+
+    dd {
+      font-size: 1.8rem;
+    }
+
+    p {
+      font-size: 1.8rem;
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.desktop} {
+    dt {
+      font-size: 2rem;
+    }
+
+    dd {
+      font-size: 1.6rem;
+    }
+
+    p {
+      font-size: 1.6rem;
+    }
   }
 `;
 

--- a/src/pages/BooksPage.tsx
+++ b/src/pages/BooksPage.tsx
@@ -20,7 +20,7 @@ const BooksPage = () => {
     isEmpty,
     message,
     isBooksFetching,
-    isBookLoading,
+    isBooksLoading,
     fetchNextPage,
     hasNextPage,
   } = useBooksInfinity();
@@ -39,7 +39,7 @@ const BooksPage = () => {
     fetchNextPage();
   };
 
-  if (!books || isBookLoading) {
+  if (!books || isBooksLoading) {
     return <Loading />;
   }
 
@@ -100,14 +100,14 @@ const BooksStyle = styled.div`
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    gap: 16px;
+    gap: 0.8rem;
   }
 
   .filter {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 10px 0;
+    flex-wrap: wrap;
   }
 
   .books {

--- a/src/pages/BooksPage.tsx
+++ b/src/pages/BooksPage.tsx
@@ -86,7 +86,7 @@ const BooksPage = () => {
 const BooksStyle = styled.div`
   width: 100%;
   margin: 0 auto;
-  max-width: ${({ theme }) => theme.layout.width.large};
+  /* max-width: ${({ theme }) => theme.layout.width.large}; */
   height: 100%;
   padding: 2rem;
 

--- a/src/pages/CartPage.tsx
+++ b/src/pages/CartPage.tsx
@@ -76,7 +76,9 @@ const CartPage = () => {
       totalQuantity,
     };
 
-    navigate("/orders", { state: orderData });
+    const orderTotalData = carts.filter((item) => selectedItems.includes(item.cartItemId));
+    console.log(orderTotalData);
+    navigate("/orders", { state: { orderData, orderTotalData } });
   };
 
   return (
@@ -118,29 +120,34 @@ const CartPage = () => {
 export const CartPageStyle = styled.div`
   width: 100%;
   margin: 0 auto;
-  max-width: ${({ theme }) => theme.layout.width.large};
   padding: 2rem;
 
   .container {
     display: flex;
     justify-content: space-between;
     gap: 2rem;
-    flex-wrap: wrap;
   }
 
   .contents {
-    flex: 3;
+    flex: 3 1 auto;
     display: flex;
     flex-direction: column;
     gap: 1rem;
     margin: 0;
-    min-width: 300px;
+    min-width: 250px;
+    width: 70%;
   }
 
   .summary {
     display: flex;
     flex-direction: column;
-    flex: 1;
+    flex: 1 1 30%;
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    .container {
+      flex-wrap: wrap;
+    }
   }
 `;
 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -4,10 +4,13 @@ import MainBest from "@/components/main/MainBest";
 import MainNewBooks from "@/components/main/MainNewBooks";
 import MainReview from "@/components/main/MainReview";
 import { useMain } from "@/hooks/useMain";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 import styled from "styled-components";
 
 const HomePage = () => {
   const { reviews, newBooks, bestBooks, banners } = useMain();
+  const { isMobile } = useMediaQuery();
+  console.log(isMobile);
 
   return (
     <HomePageStyle>
@@ -29,7 +32,7 @@ const HomePage = () => {
 };
 
 const HomePageStyle = styled.div`
-  margin: 1rem 0;
+  margin: 2rem 0;
   display: flex;
   flex-direction: column;
   gap: 2rem;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,21 +1,46 @@
-import Button from "../components/common/Button";
-import InputText from "../components/common/InputText";
-import Title from "../components/common/Title";
+import Title from "@/components/common/Title";
+import Banner from "@/components/common/banner/Banner";
+import MainBest from "@/components/main/MainBest";
+import MainNewBooks from "@/components/main/MainNewBooks";
+import MainReview from "@/components/main/MainReview";
+import { useMain } from "@/hooks/useMain";
+import styled from "styled-components";
 
 const HomePage = () => {
+  const { reviews, newBooks, bestBooks, banners } = useMain();
+
   return (
-    <>
-      <section>
-        <Title size="medium" color="secondary">
-          Home
-        </Title>
-        <InputText placeholder="입력하세요." />
-        <Button size="large" scheme="primary" isLoading={false} disabled={false}>
-          Button
-        </Button>
+    <HomePageStyle>
+      <Banner banners={banners} />
+      <section className="section">
+        <Title size="large">베스트 셀러</Title>
+        <MainBest books={bestBooks} />
       </section>
-    </>
+      <section className="section">
+        <Title size="large">신간 안내</Title>
+        <MainNewBooks books={newBooks} />
+      </section>
+      <section className="section">
+        <Title size="large">최신 리뷰</Title>
+        <MainReview reviews={reviews} />
+      </section>
+    </HomePageStyle>
   );
 };
+
+const HomePageStyle = styled.div`
+  margin: 1rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+
+  .section {
+    padding: 1rem 0;
+
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+`;
 
 export default HomePage;

--- a/src/pages/JoinPage.tsx
+++ b/src/pages/JoinPage.tsx
@@ -51,6 +51,7 @@ const JoinPage = () => {
             <InputText
               placeholder="이름을 입력해주세요."
               type="text"
+              inputMode="text"
               $isError={errors.name ? true : false}
               {...register("name", nameOptions)}
             />
@@ -60,6 +61,7 @@ const JoinPage = () => {
             <InputText
               placeholder="가입할 이메일을 입력해주세요."
               type="text"
+              inputMode="email"
               $isError={errors.email || (!errors.email && lastEmail) ? true : false}
               {...register("email", { ...emailOptions, onChange: handleOnChange })}
             />
@@ -70,6 +72,7 @@ const JoinPage = () => {
             <InputText
               placeholder="비밀번호를 입력해주세요."
               type="password"
+              inputMode="text"
               $isError={errors.password ? true : false}
               {...register("password", passwordOptions)}
             />
@@ -79,6 +82,7 @@ const JoinPage = () => {
             <InputText
               placeholder="연락처를 입력해주세요."
               type="tel"
+              inputMode="tel"
               $isError={errors.contact ? true : false}
               {...register("contact", contactOptions)}
             />
@@ -94,14 +98,14 @@ const JoinPage = () => {
               이미 가입되어 있으신가요?&nbsp;&nbsp;&nbsp;
               <Link to="/login">
                 <FaSignInAlt />
-                &nbsp;로그인 하기
+                로그인 하기
               </Link>
             </div>
             <div className="reset-link">
               비밀번호를 변경하실 건가요?&nbsp;&nbsp;&nbsp;
               <Link to="/reset">
                 <FaWhmcs />
-                &nbsp;비밀번호 초기화
+                비밀번호 초기화
               </Link>
             </div>
           </fieldset>
@@ -113,20 +117,19 @@ const JoinPage = () => {
 
 export const JoinPageStyle = styled.div`
   width: 100%;
-  /* height: 50%; */
   display: flex;
   justify-content: center;
   align-items: center;
   margin: 100px auto;
 
   .container {
-    max-width: ${({ theme }) => theme.layout.width.small};
+    max-width: 400px;
     width: 100%;
     padding-bottom: 3rem;
-    /* height: 50%; */
   }
 
   fieldset {
+    width: 100%;
     border: none;
     margin: 0;
     padding: 0;
@@ -144,6 +147,9 @@ export const JoinPageStyle = styled.div`
 
   .login-link,
   .reset-link {
+    width: 100%;
+    font-size: 1.6rem;
+    white-space: nowrap;
     a {
       text-decoration: none;
       font-weight: bold;
@@ -151,6 +157,26 @@ export const JoinPageStyle = styled.div`
       &:hover {
         opacity: 0.8;
       }
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    .container {
+      max-width: ${({ theme }) => theme.layout.width.small};
+    }
+    .login-link,
+    .reset-link {
+      font-size: 2rem;
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    .container {
+      max-width: ${({ theme }) => theme.layout.width.small};
+    }
+    .login-link,
+    .reset-link {
+      font-size: 1.6rem;
     }
   }
 `;

--- a/src/pages/JoinPage.tsx
+++ b/src/pages/JoinPage.tsx
@@ -43,8 +43,8 @@ const JoinPage = () => {
   };
 
   return (
-    <>
-      <JoinPageStyle>
+    <JoinPageStyle>
+      <div className="container">
         <Title size="large">회원가입</Title>
         <form onSubmit={handleSubmit(onSubmit)} noValidate>
           <fieldset>
@@ -106,14 +106,25 @@ const JoinPage = () => {
             </div>
           </fieldset>
         </form>
-      </JoinPageStyle>
-    </>
+      </div>
+    </JoinPageStyle>
   );
 };
 
 export const JoinPageStyle = styled.div`
-  max-width: ${({ theme }) => theme.layout.width.small};
-  margin: 80px auto;
+  width: 100%;
+  /* height: 50%; */
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 100px auto;
+
+  .container {
+    max-width: ${({ theme }) => theme.layout.width.small};
+    width: 100%;
+    padding-bottom: 3rem;
+    /* height: 50%; */
+  }
 
   fieldset {
     border: none;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -27,8 +27,8 @@ const LoginPage = () => {
   };
 
   return (
-    <>
-      <JoinPageStyle>
+    <JoinPageStyle>
+      <div className="container">
         <Title size="large">로그인</Title>
         <form onSubmit={handleSubmit(onSubmit)} noValidate>
           <fieldset>
@@ -77,8 +77,8 @@ const LoginPage = () => {
             </div>
           </fieldset>
         </form>
-      </JoinPageStyle>
-    </>
+      </div>
+    </JoinPageStyle>
   );
 };
 

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -35,6 +35,7 @@ const LoginPage = () => {
             <InputText
               placeholder="이메일을 입력해주세요."
               type="email"
+              inputMode="email"
               $isError={!errorMsg && errors.email ? true : false}
               {...register("email", emailOptions)}
             />
@@ -46,6 +47,7 @@ const LoginPage = () => {
             <InputText
               placeholder="비밀번호를 입력해주세요."
               type="password"
+              inputMode="text"
               $isError={!errorMsg && errors.password ? true : false}
               {...register("password", passwordOptions)}
             />
@@ -65,14 +67,14 @@ const LoginPage = () => {
               아직 회원이 아니신가요?&nbsp;&nbsp;&nbsp;
               <Link to="/join">
                 <FaRegUser />
-                &nbsp;회원가입 하기
+                회원가입 하기
               </Link>
             </div>
             <div className="reset-link">
               비밀번호를 변경하실 건가요?&nbsp;&nbsp;&nbsp;
               <Link to="/reset">
                 <FaWhmcs />
-                &nbsp;비밀번호 초기화
+                비밀번호 초기화
               </Link>
             </div>
           </fieldset>

--- a/src/pages/OrderList.tsx
+++ b/src/pages/OrderList.tsx
@@ -38,7 +38,6 @@ const OrderListPage = () => {
               <th>대표 상품명</th>
               <th>결제 수량</th>
               <th>결제 금액</th>
-              <th></th>
             </tr>
           </thead>
           <tbody>
@@ -46,7 +45,20 @@ const OrderListPage = () => {
               return (
                 <React.Fragment key={order.orderId}>
                   <tr>
-                    <td>{order.orderId}</td>
+                    <td>
+                      <div className="order-num">
+                        {order.orderId}
+                        <Button
+                          size="small"
+                          scheme="normal"
+                          onClick={() => {
+                            handleDetailButton(order.orderId);
+                          }}
+                        >
+                          상세보기
+                        </Button>
+                      </div>
+                    </td>
                     <td>{formatDate(order.createdAt, "YYYY.MM.DD")}</td>
                     <td>{order.delivery.address}</td>
                     <td>{order.delivery.receiver}</td>
@@ -54,22 +66,11 @@ const OrderListPage = () => {
                     <td>{order.mainBookTitle}</td>
                     <td>{order.totalQuantity}</td>
                     <td>{formatNumber(order.totalPrice)}원</td>
-                    <td>
-                      <Button
-                        size="small"
-                        scheme="normal"
-                        onClick={() => {
-                          handleDetailButton(order.orderId);
-                        }}
-                      >
-                        상세보기
-                      </Button>
-                    </td>
                   </tr>
-                  {selectedOrderId === order.orderId && isOpen && (
+                  {selectedOrderId === order.orderId && isOpen && order.detail && (
                     <tr>
-                      <td colSpan={9}>
-                        {order.detail?.map((item) => {
+                      <td colSpan={8}>
+                        {order.detail.map((item) => {
                           return <OrderItemDetail key={item.bookId} orderItem={item} />;
                         })}
                       </td>
@@ -87,8 +88,6 @@ const OrderListPage = () => {
 
 const OrderListPageStyle = styled.div`
   width: 100%;
-  margin: 0 auto;
-  max-width: ${({ theme }) => theme.layout.width.large};
   padding: 2rem;
 
   display: flex;
@@ -96,6 +95,7 @@ const OrderListPageStyle = styled.div`
 
   .order-contents {
     display: flex;
+    justify-content: center;
     width: 100%;
   }
 
@@ -106,12 +106,16 @@ const OrderListPageStyle = styled.div`
     border-bottom: 1px solid ${({ theme }) => theme.color.border};
     word-break: keep-all;
 
+    .order-num {
+      display: flex;
+      flex-direction: column;
+    }
     th,
     td {
       padding: 1rem;
       border-bottom: 1px solid ${({ theme }) => theme.color.border};
       text-align: center;
-      font-size: 1.2rem;
+      font-size: 1.3rem;
     }
 
     .detail {
@@ -126,6 +130,24 @@ const OrderListPageStyle = styled.div`
           padding: 0.5rem 1rem;
           gap: 0.5rem;
         }
+      }
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    table {
+      th,
+      td {
+        font-size: 2rem;
+      }
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    table {
+      th,
+      td {
+        font-size: 1.5rem;
       }
     }
   }

--- a/src/pages/OrderPage.tsx
+++ b/src/pages/OrderPage.tsx
@@ -10,6 +10,10 @@ import { Delivery, Order } from "@/models/order.model";
 import { useAlert } from "@/hooks/useAlert";
 import FindAddressButton from "@/components/order/FindAddressButton";
 import { requestOrder } from "@/api/order.api";
+import { FaAngleDown } from "@react-icons/all-files/fa/FaAngleDown";
+import { FaAngleUp } from "@react-icons/all-files/fa/FaAngleUp";
+import { useState } from "react";
+import OrderDetailSummary from "@/components/order/OrderDetailSummary";
 
 interface DeliveryProps extends Delivery {
   detailAddress: string;
@@ -17,10 +21,11 @@ interface DeliveryProps extends Delivery {
 
 const OrderPage = () => {
   const location = useLocation();
-  const orderDataFromCart = location.state;
+  const { orderData: orderDataFromCart, orderTotalData } = location.state;
   const { totalPrice, totalQuantity, mainBookTitle } = orderDataFromCart;
   const { showAlert, showConfirm } = useAlert();
   const navigate = useNavigate();
+  const [isClicked, setIsClicked] = useState<boolean>(false);
   const {
     register,
     handleSubmit,
@@ -66,6 +71,10 @@ const OrderPage = () => {
                 ? `${mainBookTitle} 외 총 ${totalQuantity}권`
                 : `${mainBookTitle} 총 ${totalQuantity}권`}
             </strong>
+            <button className="order-detail-btn" onClick={() => setIsClicked((prev) => !prev)}>
+              {isClicked ? <FaAngleUp /> : <FaAngleDown />}
+            </button>
+            {isClicked && <OrderDetailSummary orderItems={orderTotalData} />}
           </div>
           <section className="order-info">
             <Title size="medium" color="text">
@@ -75,19 +84,31 @@ const OrderPage = () => {
               <fieldset>
                 <label>받는 분</label>
                 <div className="input">
-                  <InputText type="text" {...register("receiver", { required: true })} />
+                  <InputText
+                    type="text"
+                    inputMode="text"
+                    {...register("receiver", { required: true })}
+                  />
                 </div>
               </fieldset>
               <fieldset>
                 <label>연락처</label>
                 <div className="input">
-                  <InputText type="text" {...register("contact", { required: true })} />
+                  <InputText
+                    type="tel"
+                    inputMode="tel"
+                    {...register("contact", { required: true })}
+                  />
                 </div>
               </fieldset>
               <fieldset>
                 <label>주소</label>
                 <div className="input">
-                  <InputText type="text" {...register("address", { required: true })} />
+                  <InputText
+                    type="text"
+                    inputMode="text"
+                    {...register("address", { required: true })}
+                  />
                   <FindAddressButton
                     onCompleted={(address) => {
                       setValue("address", address);
@@ -98,7 +119,11 @@ const OrderPage = () => {
               <fieldset>
                 <label>상세 주소</label>
                 <div className="input">
-                  <InputText type="text" {...register("detailAddress", { required: true })} />
+                  <InputText
+                    type="text"
+                    inputMode="text"
+                    {...register("detailAddress", { required: true })}
+                  />
                 </div>
               </fieldset>
             </form>
@@ -116,14 +141,21 @@ const OrderPage = () => {
 };
 
 const OrderPageStyle = styled(CartPageStyle)`
+  .container {
+    width: 100%;
+    margin-top: 1rem;
+  }
+
   .order-info {
     h1 {
       padding: 0 0 1.3rem 0;
     }
 
     strong {
-      font-size: 1.2rem;
+      font-size: 1.6rem;
+      color: ${({ theme }) => theme.color.primary};
     }
+
     padding: 1rem;
     border: 1px solid ${({ theme }) => theme.color.border};
     border-radius: ${({ theme }) => theme.borderRadius.default};
@@ -138,23 +170,61 @@ const OrderPageStyle = styled(CartPageStyle)`
       display: flex;
       justify-content: flex-start;
       gap: 0.5rem;
-      font-size: 1.2rem;
+      font-size: 1.5rem;
 
       label {
-        width: 80px;
+        white-space: nowrap;
+        width: 60px;
       }
 
       .input {
         flex: 1;
         display: flex;
-
         gap: 0.5rem;
 
         input {
           width: 100%;
-          font-size: 1.2rem;
+          font-size: 1.6rem;
         }
       }
+    }
+  }
+
+  .order-detail-btn {
+    border: none;
+    background: none;
+    padding: 0;
+    width: 2.4rem;
+    height: 2.4rem;
+    font-size: 1.6rem;
+    text-align: center;
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.mobile} {
+    label,
+    .order-info strong {
+      font-size: 2.2rem;
+    }
+    .delivery fieldset .input input {
+      font-size: 2rem;
+    }
+    .order-detail-btn {
+      font-size: 2.2rem;
+    }
+  }
+
+  @media ${({ theme }) => theme.mediaQuery.tablet} {
+    label,
+    .order-info strong {
+      font-size: 1.8rem;
+    }
+
+    .delivery fieldset .input input {
+      font-size: 1.6rem;
+    }
+
+    .order-detail-btn {
+      font-size: 1.8rem;
     }
   }
 `;

--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -51,6 +51,7 @@ const ResetPasswordPage = () => {
             <InputText
               placeholder="이메일을 입력해주세요."
               type="email"
+              inputMode="email"
               disabled={resetRequested}
               $isError={errors.email ? true : false}
               {...register("email", {
@@ -67,6 +68,7 @@ const ResetPasswordPage = () => {
                 <InputText
                   placeholder="새로운 비밀번호를 입력해주세요."
                   type="password"
+                  inputMode="text"
                   $isError={errors.password ? true : false}
                   {...register("password", passwordOptions)}
                 />
@@ -76,6 +78,7 @@ const ResetPasswordPage = () => {
                 <InputText
                   placeholder="새로운 비밀번호를 한번 더 입력해주세요."
                   type="password"
+                  inputMode="text"
                   $isError={errors.confirmPassword ? true : false}
                   {...register("confirmPassword", {
                     ...passwordOptions,

--- a/src/store/cartStore.ts
+++ b/src/store/cartStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface CartStore {
+  cartItemsCount: number;
+  updateCartItemsCount: (count: number) => void;
+}
+
+export const useCartStore = create<CartStore>((set) => ({
+  cartItemsCount: 0,
+  updateCartItemsCount: (count: number) => {
+    set({ cartItemsCount: count });
+  },
+}));

--- a/src/style/global.ts
+++ b/src/style/global.ts
@@ -45,80 +45,39 @@ export const GlobalStyle = createGlobalStyle<Props>`
 
 
 
-  @media (min-width: 0) and (max-width: 600px){
+  @media (min-width: 0) and (max-width: 425px){
     html {
       font-size: 1.5vw;
     }
   }
 
-  @media (min-width: 600px) and (max-width: 900px){
+  @media (min-width: 426px) and (max-width: 639px){
     html {
-      font-size: 1.2vw;
+      font-size: 1.25vw;
     }
   }
 
-  /* @media (min-width: 900px) and (max-width: 1080px){
+  @media (min-width: 640px) and (max-width: 1023px){
     html {
-      font-size: 1.2vw;
-    }
-  } */
-
-  @media (min-width: 900px) and (max-width: 1300px){
-    html {
-      font-size: 1vw;
+      font-size: 1.1vw;
     }
   }
 
-  @media (min-width: 1300px)and (max-width: 1600px) {
+  @media (min-width: 1024px) and (max-width: 1300px){
     html {
-      font-size: 0.85vw;
+      font-size: 0.9vw;
     }
   }
 
-  @media (min-width: 1600px) {
+  @media (min-width: 1301px)and (max-width: 1600px) {
     html {
       font-size: 0.75vw;
     }
   }
 
-  /* @media screen and (min-width: 0) and (max-width: 480px) and (max-aspect-ratio: 4 / 3){
-    body, html {
-      font-size: 1.5vw;
+  @media (min-width: 1601px) {
+    html {
+      font-size: 0.65vw;
     }
   }
-
-  @media screen and (min-width: 481px) and (max-width: 840px) and (max-aspect-ratio: 4 / 3) {
-    body, html {
-      font-size: 1vw;
-    }
-  }
-  
-  @media screen and (min-width: 841px) and (max-width: 1280px) and (orientation: landscape){
-    body, html {
-      font-size: .85vw;
-    }
-  }
-  @media screen and (min-width: 841px) and (max-width: 1280px) and (max-aspect-ratio: 4 / 3){
-    body, html {
-      font-size: .75vw;
-    }
-  }
-
-  @media screen and (min-width: 1281px) and (max-width: 1600px) and (orientation: landscape){
-    body, html {
-      font-size: .75vw;
-    }
-  }
-
-  @media screen and (min-width: 1601px) and (max-width: 1920px) and (orientation: landscape){
-    body, html {
-      font-size: .75vw;
-    }
-  }
-
-  @media screen and (min-width: 1921px) and (orientation: landscape){
-    body, html {
-      font-size: 14px;
-    } 
-  } */
 `;

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -16,19 +16,24 @@ export type HeadingSize = "large" | "medium" | "small";
 export type ButtonSize = "large" | "medium" | "small";
 export type ButtonScheme = "primary" | "normal";
 export type LayoutWidth = "large" | "medium" | "small";
+export type MediaQuery = "mobile" | "tablet" | "desktop";
 
 interface Theme {
   name: ThemeName;
   color: Record<ColorKey, string>;
   heading: {
-    [key in HeadingSize]: {
-      fontSize: string;
+    [key in MediaQuery]: {
+      [key in HeadingSize]: {
+        fontSize: string;
+      };
     };
   };
   buttonSize: {
-    [key in ButtonSize]: {
-      fontSize: string;
-      padding: string;
+    [key in MediaQuery]: {
+      [key in HeadingSize]: {
+        fontSize: string;
+        padding: string;
+      };
     };
   };
   buttonScheme: {
@@ -49,6 +54,9 @@ interface Theme {
       [key in LayoutWidth]: string;
     };
   };
+  mediaQuery: {
+    [key in MediaQuery]: string;
+  };
 }
 
 export const light: Theme = {
@@ -68,14 +76,38 @@ export const light: Theme = {
     arrowBackgroundColor: "rgba(0, 0, 0, 0.5)",
   },
   heading: {
-    large: { fontSize: "2.5rem" },
-    medium: { fontSize: "1.75rem" },
-    small: { fontSize: "1.5rem" },
+    mobile: {
+      large: { fontSize: "3.8rem" },
+      medium: { fontSize: "3rem" },
+      small: { fontSize: "2rem" },
+    },
+    tablet: {
+      large: { fontSize: "3rem" },
+      medium: { fontSize: "2rem" },
+      small: { fontSize: "1.5rem" },
+    },
+    desktop: {
+      large: { fontSize: "2.5rem" },
+      medium: { fontSize: "1.75rem" },
+      small: { fontSize: "1.5rem" },
+    },
   },
   buttonSize: {
-    large: { fontSize: "1.5rem", padding: "1rem 2rem" },
-    medium: { fontSize: "1.25rem", padding: "0.5rem 1.5rem" },
-    small: { fontSize: "1rem", padding: "0.25rem 0.5rem" },
+    mobile: {
+      large: { fontSize: "2.5rem", padding: "1rem 2rem" },
+      medium: { fontSize: "2.3rem", padding: "0.5rem 1.5rem" },
+      small: { fontSize: "2.1rem", padding: "0.25rem 0.5rem" },
+    },
+    tablet: {
+      large: { fontSize: "2rem", padding: "1rem 2rem" },
+      medium: { fontSize: "1.8rem", padding: "0.5rem 1.5rem" },
+      small: { fontSize: "1.6rem", padding: "0.25rem 0.5rem" },
+    },
+    desktop: {
+      large: { fontSize: "1.5rem", padding: "1rem 2rem" },
+      medium: { fontSize: "1.25rem", padding: "0.5rem 1.5rem" },
+      small: { fontSize: "1rem", padding: "0.25rem 0.5rem" },
+    },
   },
   buttonScheme: {
     primary: { color: "#231F20", backgroundColor: "#F4C6C6" },
@@ -94,6 +126,11 @@ export const light: Theme = {
       medium: "760px",
       small: "320px",
     },
+  },
+  mediaQuery: {
+    mobile: "(min-width: 0) and (max-width: 767px)", // 767px 이하
+    tablet: "(min-width: 768px) and (max-width: 1023px)", // 1023px 이하
+    desktop: "(min-width: 1024px)", // 1024px 이상
   },
 };
 

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -10,7 +10,8 @@ export type ColorKey =
   | "inputText"
   | "themeIconColor"
   | "authIconColor"
-  | "toastColor";
+  | "toastColor"
+  | "arrowBackgroundColor";
 export type HeadingSize = "large" | "medium" | "small";
 export type ButtonSize = "large" | "medium" | "small";
 export type ButtonScheme = "primary" | "normal";
@@ -64,6 +65,7 @@ export const light: Theme = {
     themeIconColor: "#FA6607",
     authIconColor: "#5b5b5b",
     toastColor: "#d9d2e9",
+    arrowBackgroundColor: "rgba(0, 0, 0, 0.5)",
   },
   heading: {
     large: { fontSize: "2.5rem" },
@@ -110,6 +112,7 @@ export const dark: Theme = {
     themeIconColor: "#4799e2",
     authIconColor: "#ececec",
     toastColor: "#0a4981",
+    arrowBackgroundColor: "rgba(111, 111, 111, 0.5)",
   },
   buttonScheme: {
     primary: { color: "#231F20", backgroundColor: "#e3e3e3" },


### PR DESCRIPTION
## 메인화면 구현
- [x] 배너 섹션
- [x] 베스트 셀러 섹션
- [x] 신간 도서 섹션
- [x] 최신 리뷰 섹션

## 장바구니 페이지
- 인증된 사용자의 경우, `Header` 컴포넌트에 장바구니 아이콘이 보이도록 설정
  - 장바구니 아이콘 위에 사용자가 장바구니에 담은 물품 수량을 표시하도록 구현
  - 이를 위해 장바구니 수량 정보를 관리하는 전역 state(`CartStore`) 생성
 
## 상세 작업 내용
 ### 1) 메인 화면(`HomPage`)
1. Banner 섹션
- faker api 이용하여 모크 데이터 생성
- useMain 커스텀 훅에서 배너에 보여질 데이터를 모킹 응답 받는다.
- 배너 영역은 커스텀 슬라이드로 직접 구현
- 자연스러운 transition 효과를 위해, 배너 데이터를 담고있는 banners 배열의 맨 첫 요소를 가장 마지막 요소에 추가하고 banners 배열의 마지막 요소를 가장 처음 요소에 추가한 새로운 배열인 slideBanners라는 state 생성
  - banners의 마지막 요소에서 우클릭 할 경우 오른쪽 방향으로 진행되는 transition을 통해 다시 맨 앞 요소가 보여지고, banners의 첫번째 요소에서 좌클릭 할 경우 왼쪽 방향으로 진행되는 transition을 통해 다시 맨 뒤 요소가 보여지도록 구현하기 위함
- 왼쪽 버튼 클릭시 이전 배너 이미지가 보이고, 오른쪽 버튼 클릭 시 다음 배너 이미지가 보임
- 배너의 indicator는 banners의 length만큼만 생성하고, 현재 배너 화면에 보여지는 banner의 id값과 일치하는 index로 셋팅(banner의 id는 0부터 순서대로 count되어 있음. 즉, banner.id === banners 배열의 index)
- 현재 화면에 보여지는 index를 관리하는 currentIdx state를 이용하여, slideBanners의 가장 마지막 요소(banners 배열의 가장 처음 요소)에 도달할 경우, setTimeout을 이용하여 트랜지션 지속시간인 500ms만큼 지난 후 currentIdx 값을 slideBanners 배열의 두번째 요소(banners 배열의 첫번째 요소)로 셋팅
  - 이때, transition 효과는 제거하기 위해 setIsTransition(false)수행
- 마찬가지로, slideBanners의 가장 첫 요소(banners 배열의 가장 마지막 요소)에 도달할 경우 setTimeout을 통해 500ms 지난 후 currentIdx 값을 slideBanners 배열의 뒤에서 2번째 요소(banners 배열의 마지막 요소)로 셋팅
  - 이때, transition 효과는 제거하기 위해 setIsTransition(false)수행
- slideBanners에서의 양 끝 요소 도달 시 자연스러운 transition 효과와 현재 배너에 보여지는 요소의 indicator를 바로 active한 상태로 설정해주기 위해 currentIdx와 indicatorIdx state를 분리하여 관리
  - 분리하지 않으면, 양 끝 요소에서 setTimeout에 의해 다음 트랜지션이 무시될 때 currentIdx가 변경되는데, 이때 active한 indecator도 바뀌기 때문에 indicator의 색깔 변화에 0.5초 딜레이가 걸린다. => indicator에도 딜레이 걸려서 색깔 변화가 깔끔하게 동작하지 않는 느낌을 줌
- setInterval을 이용하여 배너의 슬라이드가 3초에 한번씩 자동으로 다음 슬라이도로 넘어가도록 구현

2. 베스트 셀러 섹션
- faker api와 mock api를 이용하여 모킹 응답 받음

3. 신간 도서 섹션
- 실제 db에 저장되어 있는 신간 도서 4개를 받아온다.

4. 최신 리뷰 섹션
- faker api와 mock api를 이용하여 모킹 응답 받음
- 최신 리뷰 섹션의 슬라이드는 react slick 라이브러리를 이용하여 간단하게 구현

### 2) 장바구니 전역 store
1. Header컴포넌트에 있는 auth 요소 부분을 AuthHeader와 UnAuthHeader로 분리시킴
- 헤더 수정 전 : 인증된 사용자(로그인한 사용자)일 경우, 헤더에 보여지는 user icon을 클릭 시 드롭다운 리스트가 생기고, 드롭다운 리스트 내부에 장바구니로 가는 링크가 있었음
- 헤더 수정 후 : 인증된 사용자일 경우, user icon 좌측에 장바구니 링크 아이콘이 보이도록 수정. 이때 장바구니에 담긴 물품의 수량 표시도 함께 보이도록 만들었음

2. CartStore 생성
- 로그인한 사용자일 경우, 장바구니 아이콘 위에 장바구니에 담긴 아이템의 수량을 표시해주기 위해 전역으로 장바구니 수량 데이터를 관리할 CartStore 생성
- cartStore에서 관리하는 전역 상태 cartItemsCount는 AuthHeader에서 cart 아이콘 위에 표시하기 위해 사용된다.

3. useBookDetail 커스텀 훅 수정
- 서버로부터 응답 받은 message를 관리할 state 생성
- 장바구니에 추가하는 요청을 성공한 경우, 전역으로 관리하는 cartItemsCount 상태도 업데이트 시켜줌

4. useCarts 커스텀 훅 수정
- 장바구니 삭제 요청 성공 시, 전역으로 관리하는 cartItemsCount 상태도 업데이트 시킴

### 3) 모바일 대응
1. useMediaQuery 커스텀 훅
- 미디어 쿼리를 사용하여 현재 화면이 모바일 디바이스인지 여부를 감지하는 커스텀 훅
- 컴포넌트에서 미디어 쿼리에 따라 동적으로 UI를 조절하는데 사용
- 뷰포트의 크기에 따라 미디어쿼리 범위에 맞는 css 및 UI를 적용하기 위해 미디어쿼리의 change 이벤트 리스너 등록
- isMoblie이라는 boolean 값을 return => 컴포넌트에서 현재 디바이스가 모바일 기기인지 판단 가능

2. Header 컴포넌트 수정
- Header 컴포넌트의 우측 상단에 위치한 ThemeSwitcher 컴포넌트에서, 현재 디바이스가 mobile일 경우 mode이름은 보여주지 않도록 설정

3. InputText 컴포넌트에 inputMode 속성 추가
- 모바일 대응을 위한 속성 추가 : 모바일 사용 시, 입력 input type에 맞는 적절한 자판을 띄워줌

4. OrderDetailSummary 컴포넌트 생성
- 주문하기 페이지에서 주문할 상품에 대한 요약 정보를 보여주는 컴포넌트

5. 모바일 대응을 위한 css 수정
- 전체적으로 미디어쿼리를 적용하여 모바일 대응을 하는 반응형 웹 구현을 위한 css 수정

## 발생한 이슈
- 문제 상황 : 장바구니 아이템을 선택(체크)한 후, 해당 아이템의 삭제 버튼을 클릭하면 해당 아이템이 사라지지만 selectedItems state에는 선택한 아이템의 cart id 정보가 그대로 남아있는 문제 발견
  - 이로 인해 선택한 아이템을 삭제한 후 바로 결제하기 버튼을 누르면 현재 아무것도 선택한 아이템이 없더라도 주문 페이지로 이동됨 => 삭제한 아이템 id가 여전히 selectedItems에 남아있기 때문
- [x] 문제 해결 : 아이템을 삭제하는 버튼 클릭 시 호출되는 handleOnDelete 핸들러 내부에서, 해당 cart id가 selectedItems 배열에 포함되어 있을 경우, selectedItems에서 해당 cart id를 제거시키는 함수 추가 호출 