### PR TITLE
[bug]: 도서 조회 페이지 무한 스크롤 버그 해결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { RouterProvider } from "react-router-dom";
 import { router } from "./routers/router";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "./api/queryClient";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+// import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import ToastContainer from "./components/common/toast/ToastContainer";
 
 function App() {
@@ -13,7 +13,7 @@ function App() {
         <RouterProvider router={router} />
         <ToastContainer />
       </BookShopThemeProvider>
-      <ReactQueryDevtools />
+      {/* <ReactQueryDevtools /> */}
     </QueryClientProvider>
   );
 }

--- a/src/api/aladin.api.ts
+++ b/src/api/aladin.api.ts
@@ -97,6 +97,10 @@ const fetchBookListByCategory = async (
   return data;
 };
 
+interface FetchBooksData {
+  books: AladinBook[];
+  pagination: Pagination;
+}
 export const fetchBookList = async (
   queryType: ListQueryType,
   category: string | null,
@@ -106,8 +110,11 @@ export const fetchBookList = async (
   try {
     const { data } = await fetchBookListByCategory(queryType, category, start, limit);
 
-    const booksData: AladinBook[] = convertBooksData(data);
-    return booksData;
+    const books: AladinBook[] = convertBooksData(data.item);
+    const pagination: Pagination = { totalBooks: data.totalResults, page: data.startIndex };
+    const bookList: FetchBooksData = { books, pagination };
+    console.log(bookList);
+    return bookList;
   } catch (err) {
     throw err;
   }
@@ -159,10 +166,6 @@ export const fetchBookDetail = async (itemId: string) => {
   }
 };
 
-interface SearchBooksData {
-  searchBooks: AladinBook[];
-  pagination: Pagination;
-}
 export const fetchSearch = async (searchKeyword: string | null, start: number) => {
   try {
     const params: SearchBookParams = {
@@ -177,10 +180,10 @@ export const fetchSearch = async (searchKeyword: string | null, start: number) =
     const queryString = convertParamsToQueryString(params);
     const { data } = await httpClient.get(`/aladin/search?${queryString}`);
 
-    const searchBooks: AladinBook[] = convertBooksData(data.item);
+    const books: AladinBook[] = convertBooksData(data.item);
     const pagination: Pagination = { totalBooks: data.totalResults, page: data.startIndex };
-    const searchBooksData: SearchBooksData = { searchBooks, pagination };
-    return searchBooksData;
+    const searchBookList: FetchBooksData = { books, pagination };
+    return searchBookList;
   } catch (err) {
     throw err;
   }

--- a/src/hooks/useAladinBooks.ts
+++ b/src/hooks/useAladinBooks.ts
@@ -3,6 +3,7 @@ import { queryKey } from "@/constants/queryKey";
 import { fetchBookList } from "@/api/aladin.api";
 import { useLocation } from "react-router-dom";
 import { QUERYSTRING } from "@/constants/querystring";
+import { MAXRESULTS } from "@/constants/querystring";
 
 export const useAladinBooks = () => {
   const location = useLocation();
@@ -12,19 +13,30 @@ export const useAladinBooks = () => {
     searchParams.get(QUERYSTRING.NEW) === "true" ? "ItemNewSpecial" : "ItemEditorChoice";
   const queryType = categoryId === null && isNew === "ItemEditorChoice" ? "Bestseller" : isNew;
 
-  const { data, isLoading, isFetching, fetchNextPage, hasNextPage } = useInfiniteQuery({
+  const {
+    data: aladinBooks,
+    isLoading,
+    isFetching,
+    fetchNextPage,
+    hasNextPage,
+  } = useInfiniteQuery({
     queryKey: [queryKey.aladinBooks, location.search],
     queryFn: ({ pageParam = 1 }) => fetchBookList(queryType, categoryId, pageParam),
-    getNextPageParam: (_, allPages): number | null => {
-      return allPages.length < 10 ? allPages.length + 1 : null;
+    getNextPageParam: (lastPage) => {
+      const currentPage = lastPage.pagination.page;
+      const totalPages = Math.ceil(lastPage.pagination.totalBooks / MAXRESULTS);
+      return currentPage < totalPages ? currentPage + 1 : null;
     },
     initialPageParam: 1,
     staleTime: 1000 * 60 * 60 * 18,
     gcTime: 1000 * 60 * 60 * 24,
   });
 
-  const books = data?.pages[0].length ? data.pages.flat() : [];
-  const isEmpty = books.length === 0;
+  const books =
+    aladinBooks?.pages[0].pagination.totalBooks !== 0
+      ? aladinBooks?.pages.flatMap((page) => page.books)
+      : [];
+  const isEmpty = !books || books.length === 0;
 
   return {
     aladinBooks: books,

--- a/src/hooks/useAladinSearchBook.ts
+++ b/src/hooks/useAladinSearchBook.ts
@@ -23,7 +23,7 @@ export const useAladinSearchBook = (keyword: string | null) => {
 
   const books =
     searchBooksResult?.pages[0].pagination.totalBooks !== 0
-      ? searchBooksResult?.pages.flatMap((page) => page.searchBooks)
+      ? searchBooksResult?.pages.flatMap((page) => page.books)
       : [];
 
   return {

--- a/src/hooks/useMain.ts
+++ b/src/hooks/useMain.ts
@@ -15,11 +15,11 @@ export const useMain = () => {
     });
 
     fetchBookList("ItemNewSpecial", null, 1, 10).then((booksData) => {
-      setNewBooks(booksData);
+      setNewBooks(booksData.books);
     });
 
     fetchBookList("Bestseller", null, 1, 10).then((booksData) => {
-      setBestBooks(booksData);
+      setBestBooks(booksData.books);
     });
   }, []);
 


### PR DESCRIPTION
## 관련 이슈 번호
Closed #16 

- 도서 조회 페이지에서 총 페이지가 10 미만(`allPages`배열의 길이를 10으로 설정)인 경우, 더 이상 조회될 도서가 없음에도 불구하고 추가 요청을 보내는 오류 발견
- 총 페이지를 10으로 지정해주는 바람에 발생한 문제
- 따라서, `getNextPageParam`의 `allPages`인자를 사용하지 않고 알라딘 open API를 통해 응답 받는 `totalResults`와 `startIndex`값을 전달 받아 각각 조회된 전체 도서 갯수와 현재 페이지 index 값으로 사용하도록 수정하여 해결