### PR TITLE
[refactor]: 400 에러에 대한 전역 에러 핸들링 수정

### DIFF
--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -3,6 +3,12 @@ import { getToken, removeToken, removeUserName, setToken } from "@/store/authSto
 
 const BASE_URL = process.env.REACT_APP_BASE_URL;
 const DEFAULT_TIMEOUT = Number(process.env.REACT_APP_DEFAULT_TIMEOUT);
+const loginMsg = {
+  LOGIN_BAD_REQUEST: "이메일 또는 비밀번호를 잘못 입력했습니다. 입력하신 내용을 다시 확인해주세요.",
+};
+const joinMsg = {
+  DUPLICATE_EMAIL: "이미 가입된 이메일입니다. 다른 이메일을 입력해주세요.",
+};
 
 const createClient = (config?: AxiosRequestConfig) => {
   const axiosInstance = axios.create({
@@ -47,13 +53,12 @@ const createClient = (config?: AxiosRequestConfig) => {
         removeUserName();
 
         window.alert(err.response.data.message);
-
         window.location.href = "/login";
         return;
       } else if (err.response.status === 403) {
         window.alert(err.response.data.message);
         return;
-      } else if (err.response.status === 400) {
+      } else if (err.response.status === 400 && (!joinMsg || !loginMsg)) {
         window.alert(err.response.data.message);
         return;
       } else if (err.response.status >= 500) {


### PR DESCRIPTION
## 관련 이슈 번호
Closed #18 

## 작업한 내용
- 로그인, 회원가입 시 발생한 400 오류는 응답 인터셉터에서 처리하지 않도록 수정
  - alert이 아니라 로그인 및 회원가입 폼에 직접 에러 메세지를 보여줘야 하기 때문
- 나머지 400오류는 alert으로 응답 인터셉터에서 처리 