### PR TITLE
[fix]: 카테고리 필터링 관련 쿼리스트링 불일치 문제 해결/[refactor]: 도서 목록 조회 페이지의 쿼리스트링 개선

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { RouterProvider } from "react-router-dom";
 import { router } from "./routers/router";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "./api/queryClient";
-// import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import ToastContainer from "./components/common/toast/ToastContainer";
 
 function App() {
@@ -13,7 +13,7 @@ function App() {
         <RouterProvider router={router} />
         <ToastContainer />
       </BookShopThemeProvider>
-      {/* <ReactQueryDevtools /> */}
+      <ReactQueryDevtools />
     </QueryClientProvider>
   );
 }

--- a/src/api/aladin.api.ts
+++ b/src/api/aladin.api.ts
@@ -113,7 +113,6 @@ export const fetchBookList = async (
     const books: AladinBook[] = convertBooksData(data.item);
     const pagination: Pagination = { totalBooks: data.totalResults, page: data.startIndex };
     const bookList: FetchBooksData = { books, pagination };
-    console.log(bookList);
     return bookList;
   } catch (err) {
     throw err;

--- a/src/components/books/BooksFilter.tsx
+++ b/src/components/books/BooksFilter.tsx
@@ -13,10 +13,10 @@ const BooksFilter = () => {
     return <Loading />;
   }
 
-  const resetClickedPage = (newSearchParams: URLSearchParams) => {
-    newSearchParams.set(QUERYSTRING.PAGE, "1");
-    setSearchParams(newSearchParams);
-  };
+  // const resetClickedPage = (newSearchParams: URLSearchParams) => {
+  //   newSearchParams.set(QUERYSTRING.PAGE, "1");
+  //   setSearchParams(newSearchParams);
+  // };
 
   const handleCategory = (id: number | null) => {
     const newSearchParams = new URLSearchParams(searchParams);
@@ -24,7 +24,7 @@ const BooksFilter = () => {
     id
       ? newSearchParams.set(QUERYSTRING.CATEGORY_ID, id.toString())
       : newSearchParams.delete(QUERYSTRING.CATEGORY_ID);
-    resetClickedPage(newSearchParams);
+    // resetClickedPage(newSearchParams);
     setSearchParams(newSearchParams);
   };
 
@@ -33,7 +33,7 @@ const BooksFilter = () => {
     const isNew = newSearchParams.get(QUERYSTRING.NEW);
 
     isNew ? newSearchParams.delete(QUERYSTRING.NEW) : newSearchParams.set(QUERYSTRING.NEW, "true");
-    resetClickedPage(newSearchParams);
+    // resetClickedPage(newSearchParams);
     setSearchParams(newSearchParams);
   };
 

--- a/src/components/category/Category.tsx
+++ b/src/components/category/Category.tsx
@@ -1,10 +1,11 @@
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import styled from "styled-components";
 import { useCategory } from "@/hooks/useCategory";
 
 const Category = () => {
   const { categories, isCategoriesLoading } = useCategory();
-
+  const [searchParams] = useSearchParams();
+  const view = searchParams.get("view") ? searchParams.get("view") : "grid";
   if (isCategoriesLoading || !categories) {
     return null;
   }
@@ -19,8 +20,8 @@ const Category = () => {
               <Link
                 to={`/books${
                   item.categoryId !== null
-                    ? `?page=1&view=grid&category_id=${item.categoryId}`
-                    : "?page=1&view=grid"
+                    ? `?page=1&view=${view}&category_id=${item.categoryId}`
+                    : `?page=1&view=${view}`
                 }`}
               >
                 {item.categoryName}

--- a/src/components/category/Category.tsx
+++ b/src/components/category/Category.tsx
@@ -20,8 +20,8 @@ const Category = () => {
               <Link
                 to={`/books${
                   item.categoryId !== null
-                    ? `?page=1&view=${view}&category_id=${item.categoryId}`
-                    : `?page=1&view=${view}`
+                    ? `?view=${view}&category_id=${item.categoryId}`
+                    : `?view=${view}`
                 }`}
               >
                 {item.categoryName}

--- a/src/components/category/Category.tsx
+++ b/src/components/category/Category.tsx
@@ -18,7 +18,9 @@ const Category = () => {
             <li key={item.categoryId}>
               <Link
                 to={`/books${
-                  item.categoryId !== null ? `?page=1&category_id=${item.categoryId}` : "?page=1"
+                  item.categoryId !== null
+                    ? `?page=1&view=grid&category_id=${item.categoryId}`
+                    : "?page=1&view=grid"
                 }`}
               >
                 {item.categoryName}

--- a/src/hooks/useAladinBooks.ts
+++ b/src/hooks/useAladinBooks.ts
@@ -13,14 +13,8 @@ export const useAladinBooks = () => {
     searchParams.get(QUERYSTRING.NEW) === "true" ? "ItemNewSpecial" : "ItemEditorChoice";
   const queryType = categoryId === null && isNew === "ItemEditorChoice" ? "Bestseller" : isNew;
 
-  const {
-    data: aladinBooks,
-    isLoading,
-    isFetching,
-    fetchNextPage,
-    hasNextPage,
-  } = useInfiniteQuery({
-    queryKey: [queryKey.aladinBooks, location.search],
+  const { data, isLoading, isFetching, fetchNextPage, hasNextPage } = useInfiniteQuery({
+    queryKey: [queryKey.aladinBooks, categoryId, isNew],
     queryFn: ({ pageParam = 1 }) => fetchBookList(queryType, categoryId, pageParam),
     getNextPageParam: (lastPage) => {
       const currentPage = lastPage.pagination.page;
@@ -33,9 +27,7 @@ export const useAladinBooks = () => {
   });
 
   const books =
-    aladinBooks?.pages[0].pagination.totalBooks !== 0
-      ? aladinBooks?.pages.flatMap((page) => page.books)
-      : [];
+    data?.pages[0].pagination.totalBooks !== 0 ? data?.pages.flatMap((page) => page.books) : [];
   const isEmpty = !books || books.length === 0;
 
   return {

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -13,17 +13,17 @@ export const useIntersectionObserver = (callBack: CallBack, options?: ObserverOp
 
   useEffect(() => {
     const observer = new IntersectionObserver(callBack, options);
-
+    const currentTarget = targetRef.current;
     if (targetRef.current) {
       observer.observe(targetRef.current);
     }
 
     return () => {
-      if (targetRef.current) {
-        observer.unobserve(targetRef.current);
+      if (currentTarget) {
+        observer.unobserve(currentTarget);
       }
     };
-  });
+  }, [callBack, options]);
 
   return targetRef;
 };

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -59,7 +59,7 @@ const bookInfoList = [
     label: "카테고리",
     key: "categoryName",
     filter: (book: AladinBookDetail) => (
-      <Link to={`/books?page=1&category_id=${book.categoryId}`}>{book.categoryName}</Link>
+      <Link to={`/books?&category_id=${book.categoryId}`}>{book.categoryName}</Link>
     ),
   },
   { label: "저자", key: "author" },

--- a/src/pages/BooksPage.tsx
+++ b/src/pages/BooksPage.tsx
@@ -21,14 +21,15 @@ const BooksPage = () => {
     isEmpty,
   } = useAladinBooks();
 
-  const moreRef = useIntersectionObserver(
-    ([entry]) => {
+  const callback = (entries: IntersectionObserverEntry[]) => {
+    entries.forEach((entry) => {
       if (entry.isIntersecting) {
         loadMore();
       }
-    },
-    { threshold: 0.5 },
-  );
+    });
+  };
+
+  const moreRef = useIntersectionObserver(callback, { threshold: 0.5 });
 
   const loadMore = () => {
     if (!hasNextPage || isBooksFetching) return;


### PR DESCRIPTION
## 관련 이슈 번호
Closed #21 카테고리 필터링 관련 쿼리스트링 불일치 오류 해결
Closed #22 도서 목록 조회 페이지의 쿼리스트링 개선 작업

## 작업한 내용
### 1)  드롭다운 리스트에서 카테고리 선택했을 때와 도서 목록 페이지의 카테고리 필터링 버튼 클릭했을 때 생성되는 쿼리스트링 불일치 문제 해결
- 문제 상황: 드롭다운 카테고리 클릭하면 `view` 정보가 쿼리스트링에서 누락되어 있는 문제
- 해결 방법: 드롭다운 리스트에서 카테고리 선택 시 쿼리스트링에 `view` 쿼리가 추가되도록 수정

### 2) 도서 목록 페이지 url의 쿼리 정보 수정
- 도서목록 조회 페이지 url의 쿼리스트링에서, `page` 쿼리는 제거
- 무한스크롤로 구현하기 때문에 `page` 쿼리 정보는 필요없으므로 `page` 값 설정 관련 코드는 제거

### 3) `aladinBooks` 쿼리키 종속성 수정
- `aladinBooks`쿼리키에 대한 종속성으로 쿼리스트링 전체가 아니라 카테고리 id와 최신도서 선택 여부에 대한 쿼리스트링 값으로 설정
- 쿼리스트링 전체를 종속성으로 부여하게 되면, `view`가 `gird`든 `list`든 데이터는 동일한데도 불구하고 `view` 쿼리 값에 따라서도 쿼리가 다시 실행되기 때문에 불필요한 데이터요청이 발생함
- 따라서 `aladinBooks` 쿼리키는 `view`를 제외한 나머지 쿼리스트링에 종속적이도록 수정